### PR TITLE
Add AWS S3 / S3-compatible sync backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Fatto (italian for "*done*") is a handy TaskWarrior client for Android. It syncs
 
 ## Features
 
-- **sync**: bi-directional sync with any [`taskchampion-sync-server`](https://github.com/GothenburgBitFactory/taskchampion-sync-server)
+- **sync**: bi-directional sync with any [`taskchampion-sync-server`](https://github.com/GothenburgBitFactory/taskchampion-sync-server), or directly with AWS S3 / S3-compatible storage (e.g. minio)
 - **task**: comprehensive task management with filtering, sorting, and detail editing
 - **projects**: hierarchical project management with pending task counts
 - **tags**: auto-resizing tag list with pending task counts

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,4 +1,5 @@
 - [x] sync with taskwarrior-sync-server
+- [x] sync with AWS S3 / S3-compatible storage (minio, etc.)
 - [x] show tasks and sort them
 - [x] support due date in tasks
 - [x] support scheduling tasks

--- a/android/app/src/main/kotlin/com/brokenpip3/fatto/data/DateTimeUtils.kt
+++ b/android/app/src/main/kotlin/com/brokenpip3/fatto/data/DateTimeUtils.kt
@@ -1,8 +1,33 @@
 package com.brokenpip3.fatto.data
 
+import java.time.Instant
 import java.time.LocalDate
+import java.time.OffsetDateTime
 
 object DateTimeUtils {
+    /**
+     * Parses an RFC-3339 / ISO-8601 timestamp into an [Instant], tolerating both
+     * a "Z" suffix and an explicit numeric offset (e.g. "+00:00").
+     *
+     * The Rust layer emits timestamps via chrono's `to_rfc3339()`, which renders
+     * UTC as "+00:00" rather than "Z". `Instant.parse` only accepts "Z" and would
+     * throw a `DateTimeParseException`, crashing on any task that carries a
+     * wait/due/scheduled date (common after syncing real Taskwarrior data).
+     * Returns null when the value is missing or unparseable.
+     */
+    fun parseToInstant(dateStr: String?): Instant? {
+        if (dateStr.isNullOrBlank()) return null
+        return try {
+            OffsetDateTime.parse(dateStr).toInstant()
+        } catch (e: Exception) {
+            try {
+                Instant.parse(dateStr)
+            } catch (e2: Exception) {
+                null
+            }
+        }
+    }
+
     /**
      * Extracts the date portion (YYYY-MM-DD) from an ISO-8601 string.
      * We treat dates as "floating" - if it says April 28 in UTC, it's April 28 for the user,

--- a/android/app/src/main/kotlin/com/brokenpip3/fatto/data/SettingsRepository.kt
+++ b/android/app/src/main/kotlin/com/brokenpip3/fatto/data/SettingsRepository.kt
@@ -19,6 +19,26 @@ data class SyncCredentials(
     val secret: String,
 )
 
+data class S3Credentials(
+    val bucket: String,
+    val region: String?,
+    val endpointUrl: String?,
+    val accessKeyId: String,
+    val secretAccessKey: String,
+    val secret: String,
+)
+
+/** Selected sync backend. Stored as a string under the `sync_type` preference key. */
+enum class SyncType(val value: String) {
+    SERVER("server"),
+    S3("s3"),
+    ;
+
+    companion object {
+        fun fromValue(value: String?): SyncType = entries.firstOrNull { it.value == value } ?: SERVER
+    }
+}
+
 @Suppress("TooManyFunctions")
 interface SettingsRepository {
     val showCompleted: StateFlow<Boolean>
@@ -66,11 +86,26 @@ interface SettingsRepository {
 
     fun setSortDirection(value: String)
 
+    fun getSyncType(): SyncType
+
+    fun setSyncType(type: SyncType)
+
     fun getCredentials(): SyncCredentials?
 
     fun saveCredentials(
         url: String,
         clientId: String,
+        secret: String,
+    )
+
+    fun getS3Credentials(): S3Credentials?
+
+    fun saveS3Credentials(
+        bucket: String,
+        region: String?,
+        endpointUrl: String?,
+        accessKeyId: String,
+        secretAccessKey: String,
         secret: String,
     )
 
@@ -279,6 +314,14 @@ class SettingsRepositoryImpl(context: Context) : SettingsRepository {
         _sortDirection.value = value
     }
 
+    override fun getSyncType(): SyncType {
+        return SyncType.fromValue(sharedPreferences?.getString("sync_type", null))
+    }
+
+    override fun setSyncType(type: SyncType) {
+        sharedPreferences?.edit()?.putString("sync_type", type.value)?.apply()
+    }
+
     override fun getCredentials(): SyncCredentials? {
         val prefs = sharedPreferences ?: return null
         val url = prefs.getString("sync_url", null)
@@ -291,6 +334,60 @@ class SettingsRepositoryImpl(context: Context) : SettingsRepository {
             SyncCredentials(url, clientId, secret)
         } else {
             null
+        }
+    }
+
+    override fun getS3Credentials(): S3Credentials? {
+        val prefs = sharedPreferences ?: return null
+        val bucket = prefs.getString("s3_bucket", null)
+        val accessKeyId = prefs.getString("s3_access_key_id", null)
+        val secretAccessKey = prefs.getString("s3_secret_access_key", null)
+        val secret = prefs.getString("s3_encryption_secret", null)
+        // region and endpoint are optional; blanks are treated as unset.
+        val region = prefs.getString("s3_region", null)?.takeIf { it.isNotBlank() }
+        val endpointUrl = prefs.getString("s3_endpoint_url", null)?.takeIf { it.isNotBlank() }
+
+        Log.d("SettingsRepository", "Getting S3 credentials")
+
+        return if (
+            !bucket.isNullOrBlank() &&
+            !accessKeyId.isNullOrBlank() &&
+            !secretAccessKey.isNullOrBlank() &&
+            !secret.isNullOrBlank()
+        ) {
+            S3Credentials(bucket, region, endpointUrl, accessKeyId, secretAccessKey, secret)
+        } else {
+            null
+        }
+    }
+
+    override fun saveS3Credentials(
+        bucket: String,
+        region: String?,
+        endpointUrl: String?,
+        accessKeyId: String,
+        secretAccessKey: String,
+        secret: String,
+    ) {
+        val prefs = sharedPreferences
+        if (prefs == null) {
+            Log.e("SettingsRepository", "Cannot save: SharedPreferences is null")
+            return
+        }
+        Log.d("SettingsRepository", "Saving S3 credentials")
+        try {
+            val success =
+                prefs.edit()
+                    .putString("s3_bucket", bucket)
+                    .putString("s3_region", region ?: "")
+                    .putString("s3_endpoint_url", endpointUrl ?: "")
+                    .putString("s3_access_key_id", accessKeyId)
+                    .putString("s3_secret_access_key", secretAccessKey)
+                    .putString("s3_encryption_secret", secret)
+                    .commit()
+            Log.d("SettingsRepository", "Save success: $success")
+        } catch (e: Exception) {
+            Log.e("SettingsRepository", "Failed to save S3 credentials", e)
         }
     }
 
@@ -327,6 +424,13 @@ class SettingsRepositoryImpl(context: Context) : SettingsRepository {
                     .remove("sync_url")
                     .remove("client_id")
                     .remove("encryption_secret")
+                    .remove("sync_type")
+                    .remove("s3_bucket")
+                    .remove("s3_region")
+                    .remove("s3_endpoint_url")
+                    .remove("s3_access_key_id")
+                    .remove("s3_secret_access_key")
+                    .remove("s3_encryption_secret")
                     .commit()
             Log.d("SettingsRepository", "Clear success: $success")
         } catch (e: Exception) {
@@ -335,7 +439,10 @@ class SettingsRepositoryImpl(context: Context) : SettingsRepository {
     }
 
     override fun hasCredentials(): Boolean {
-        return getCredentials() != null
+        return when (getSyncType()) {
+            SyncType.S3 -> getS3Credentials() != null
+            SyncType.SERVER -> getCredentials() != null
+        }
     }
 
     override fun getShowCompleted(): Boolean {

--- a/android/app/src/main/kotlin/com/brokenpip3/fatto/data/Syncer.kt
+++ b/android/app/src/main/kotlin/com/brokenpip3/fatto/data/Syncer.kt
@@ -1,0 +1,45 @@
+package com.brokenpip3.fatto.data
+
+import uniffi.taskchampion_android.ReplicaWrapper
+
+/**
+ * Dispatches a sync to the backend selected in settings: either a
+ * `taskchampion-sync-server` instance or an AWS S3 / S3-compatible bucket.
+ *
+ * Keeping this in one place ensures the manual sync, the reactive post-mutation
+ * sync, and the background [com.brokenpip3.fatto.worker.SyncWorker] all behave
+ * identically.
+ */
+object Syncer {
+    /**
+     * Run a sync using the configured backend.
+     *
+     * @return true if credentials were configured and a sync was attempted,
+     *   false if there is nothing to sync against. Any error raised by the
+     *   underlying replica is propagated to the caller.
+     */
+    fun sync(
+        replica: ReplicaWrapper,
+        settings: SettingsRepository,
+    ): Boolean {
+        return when (settings.getSyncType()) {
+            SyncType.S3 ->
+                settings.getS3Credentials()?.let { creds ->
+                    replica.syncAws(
+                        creds.bucket,
+                        creds.region,
+                        creds.endpointUrl,
+                        creds.accessKeyId,
+                        creds.secretAccessKey,
+                        creds.secret,
+                    )
+                    true
+                } ?: false
+            SyncType.SERVER ->
+                settings.getCredentials()?.let { creds ->
+                    replica.sync(creds.url, creds.clientId, creds.secret)
+                    true
+                } ?: false
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/brokenpip3/fatto/data/TaskRepository.kt
+++ b/android/app/src/main/kotlin/com/brokenpip3/fatto/data/TaskRepository.kt
@@ -209,8 +209,7 @@ class TaskRepository(
 
     suspend fun sync() =
         withContext(Dispatchers.IO) {
-            val creds = settingsRepository.getCredentials()
-            if (creds == null) {
+            if (!settingsRepository.hasCredentials()) {
                 Log.w("TaskRepository", "Cannot sync: No credentials found")
                 throw Exception("No sync credentials configured")
             }
@@ -218,7 +217,7 @@ class TaskRepository(
             replica?.let { r ->
                 Log.d("TaskRepository", "Starting manual sync")
                 try {
-                    r.sync(creds.url, creds.clientId, creds.secret)
+                    Syncer.sync(r, settingsRepository)
                     Log.d("TaskRepository", "Manual sync successful")
                     loadTasks()
                 } catch (e: Exception) {
@@ -232,11 +231,11 @@ class TaskRepository(
         }
 
     private suspend fun triggerSync() {
-        val creds = settingsRepository.getCredentials() ?: return
+        if (!settingsRepository.hasCredentials()) return
         replica?.let { r ->
             try {
                 Log.d("TaskRepository", "Triggering reactive sync...")
-                r.sync(creds.url, creds.clientId, creds.secret)
+                Syncer.sync(r, settingsRepository)
                 loadTasks()
             } catch (e: Exception) {
                 Log.e("TaskRepository", "Reactive sync failed", e)

--- a/android/app/src/main/kotlin/com/brokenpip3/fatto/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/kotlin/com/brokenpip3/fatto/ui/settings/SettingsScreen.kt
@@ -71,6 +71,7 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
+import com.brokenpip3.fatto.data.SyncType
 import com.brokenpip3.fatto.data.TaskrcImportPreview
 import com.brokenpip3.fatto.data.TaskrcImportResultType
 import com.brokenpip3.fatto.data.model.TaskContext
@@ -93,17 +94,31 @@ private enum class SettingsTab(
 }
 
 private data class SyncSettingsSectionState(
+    val syncType: SyncType,
     val syncUrl: String,
     val clientId: String,
     val encryptionSecret: String,
     val secretVisible: Boolean,
+    val s3Bucket: String,
+    val s3Region: String,
+    val s3EndpointUrl: String,
+    val s3AccessKeyId: String,
+    val s3SecretAccessKey: String,
+    val s3SecretVisible: Boolean,
 )
 
 private data class SyncSettingsSectionActions(
+    val onSyncTypeChange: (SyncType) -> Unit,
     val onSecretVisibleChange: (Boolean) -> Unit,
     val onSyncUrlChange: (String) -> Unit,
     val onClientIdChange: (String) -> Unit,
     val onSecretChange: (String) -> Unit,
+    val onS3BucketChange: (String) -> Unit,
+    val onS3RegionChange: (String) -> Unit,
+    val onS3EndpointUrlChange: (String) -> Unit,
+    val onS3AccessKeyIdChange: (String) -> Unit,
+    val onS3SecretAccessKeyChange: (String) -> Unit,
+    val onS3SecretVisibleChange: (Boolean) -> Unit,
     val onSave: () -> Unit,
     val onClear: () -> Unit,
 )
@@ -169,9 +184,15 @@ fun SettingsScreen(
     availableProjects: List<String>,
     availableTags: Set<String>,
 ) {
+    val syncType by viewModel.syncType.collectAsState()
     val syncUrl by viewModel.syncUrl.collectAsState()
     val clientId by viewModel.clientId.collectAsState()
     val encryptionSecret by viewModel.encryptionSecret.collectAsState()
+    val s3Bucket by viewModel.s3Bucket.collectAsState()
+    val s3Region by viewModel.s3Region.collectAsState()
+    val s3EndpointUrl by viewModel.s3EndpointUrl.collectAsState()
+    val s3AccessKeyId by viewModel.s3AccessKeyId.collectAsState()
+    val s3SecretAccessKey by viewModel.s3SecretAccessKey.collectAsState()
     val showCompleted by viewModel.showCompleted.collectAsState()
     val showInternalTags by viewModel.showInternalTags.collectAsState()
     val showEmptyProjects by viewModel.showEmptyProjects.collectAsState()
@@ -200,6 +221,7 @@ fun SettingsScreen(
     val notificationsScrollState = rememberSaveable(saver = ScrollState.Saver) { ScrollState(0) }
     val aboutScrollState = rememberSaveable(saver = ScrollState.Saver) { ScrollState(0) }
     var secretVisible by remember { mutableStateOf(false) }
+    var s3SecretVisible by remember { mutableStateOf(false) }
     var editingContext by remember { mutableStateOf<TaskContext?>(null) }
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
@@ -212,9 +234,9 @@ fun SettingsScreen(
     }
 
     val onSaveSyncSettings: () -> Unit = {
-        viewModel.save()
+        val saved = viewModel.save()
         focusManager.clearFocus()
-        launchSnackbar("Settings saved")
+        launchSnackbar(if (saved) "Settings saved" else "Fill in all required sync fields")
     }
     val onClearSyncSettings: () -> Unit = {
         viewModel.clear()
@@ -277,17 +299,31 @@ fun SettingsScreen(
                             scrollState = syncScrollState,
                             state =
                                 SyncSettingsSectionState(
+                                    syncType = syncType,
                                     syncUrl = syncUrl,
                                     clientId = clientId,
                                     encryptionSecret = encryptionSecret,
                                     secretVisible = secretVisible,
+                                    s3Bucket = s3Bucket,
+                                    s3Region = s3Region,
+                                    s3EndpointUrl = s3EndpointUrl,
+                                    s3AccessKeyId = s3AccessKeyId,
+                                    s3SecretAccessKey = s3SecretAccessKey,
+                                    s3SecretVisible = s3SecretVisible,
                                 ),
                             actions =
                                 SyncSettingsSectionActions(
+                                    onSyncTypeChange = viewModel::onSyncTypeChange,
                                     onSecretVisibleChange = { secretVisible = it },
                                     onSyncUrlChange = viewModel::onUrlChange,
                                     onClientIdChange = viewModel::onClientIdChange,
                                     onSecretChange = viewModel::onSecretChange,
+                                    onS3BucketChange = viewModel::onS3BucketChange,
+                                    onS3RegionChange = viewModel::onS3RegionChange,
+                                    onS3EndpointUrlChange = viewModel::onS3EndpointUrlChange,
+                                    onS3AccessKeyIdChange = viewModel::onS3AccessKeyIdChange,
+                                    onS3SecretAccessKeyChange = viewModel::onS3SecretAccessKeyChange,
+                                    onS3SecretVisibleChange = { s3SecretVisible = it },
                                     onSave = onSaveSyncSettings,
                                     onClear = onClearSyncSettings,
                                 ),
@@ -449,32 +485,155 @@ private fun SyncSettingsSection(
             color = MaterialTheme.colorScheme.primary,
         )
 
-        TextField(
-            value = state.syncUrl,
-            onValueChange = actions.onSyncUrlChange,
-            label = { Text("Sync Server URL") },
-            placeholder = { Text("http://example.com:8080") },
-            modifier = Modifier.fillMaxWidth(),
-            keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
-            colors =
-                TextFieldDefaults.colors(
-                    focusedContainerColor = MaterialTheme.colorScheme.surface,
-                    unfocusedContainerColor = MaterialTheme.colorScheme.surface,
-                ),
-        )
+        Row(
+            modifier = Modifier.fillMaxWidth().selectableGroup(),
+            horizontalArrangement = Arrangement.spacedBy(24.dp),
+            verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
+        ) {
+            Row(
+                modifier =
+                    Modifier
+                        .selectable(
+                            selected = state.syncType == SyncType.SERVER,
+                            onClick = { actions.onSyncTypeChange(SyncType.SERVER) },
+                            role = Role.RadioButton,
+                        ),
+                verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
+            ) {
+                RadioButton(
+                    selected = state.syncType == SyncType.SERVER,
+                    onClick = null,
+                )
+                Text(
+                    text = "Sync server",
+                    style = MaterialTheme.typography.bodyLarge,
+                    modifier = Modifier.padding(start = 8.dp),
+                )
+            }
 
-        TextField(
-            value = state.clientId,
-            onValueChange = actions.onClientIdChange,
-            label = { Text("Client ID (UUID)") },
-            placeholder = { Text("00000000-0000-0000-0000-000000000000") },
-            modifier = Modifier.fillMaxWidth(),
-            colors =
-                TextFieldDefaults.colors(
-                    focusedContainerColor = MaterialTheme.colorScheme.surface,
-                    unfocusedContainerColor = MaterialTheme.colorScheme.surface,
-                ),
-        )
+            Row(
+                modifier =
+                    Modifier
+                        .selectable(
+                            selected = state.syncType == SyncType.S3,
+                            onClick = { actions.onSyncTypeChange(SyncType.S3) },
+                            role = Role.RadioButton,
+                        ),
+                verticalAlignment = androidx.compose.ui.Alignment.CenterVertically,
+            ) {
+                RadioButton(
+                    selected = state.syncType == SyncType.S3,
+                    onClick = null,
+                )
+                Text(
+                    text = "S3 storage",
+                    style = MaterialTheme.typography.bodyLarge,
+                    modifier = Modifier.padding(start = 8.dp),
+                )
+            }
+        }
+
+        if (state.syncType == SyncType.SERVER) {
+            TextField(
+                value = state.syncUrl,
+                onValueChange = actions.onSyncUrlChange,
+                label = { Text("Sync Server URL") },
+                placeholder = { Text("http://example.com:8080") },
+                modifier = Modifier.fillMaxWidth(),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+                colors =
+                    TextFieldDefaults.colors(
+                        focusedContainerColor = MaterialTheme.colorScheme.surface,
+                        unfocusedContainerColor = MaterialTheme.colorScheme.surface,
+                    ),
+            )
+
+            TextField(
+                value = state.clientId,
+                onValueChange = actions.onClientIdChange,
+                label = { Text("Client ID (UUID)") },
+                placeholder = { Text("00000000-0000-0000-0000-000000000000") },
+                modifier = Modifier.fillMaxWidth(),
+                colors =
+                    TextFieldDefaults.colors(
+                        focusedContainerColor = MaterialTheme.colorScheme.surface,
+                        unfocusedContainerColor = MaterialTheme.colorScheme.surface,
+                    ),
+            )
+        } else {
+            TextField(
+                value = state.s3Bucket,
+                onValueChange = actions.onS3BucketChange,
+                label = { Text("Bucket") },
+                placeholder = { Text("my-tasks-bucket") },
+                modifier = Modifier.fillMaxWidth(),
+                colors =
+                    TextFieldDefaults.colors(
+                        focusedContainerColor = MaterialTheme.colorScheme.surface,
+                        unfocusedContainerColor = MaterialTheme.colorScheme.surface,
+                    ),
+            )
+
+            TextField(
+                value = state.s3EndpointUrl,
+                onValueChange = actions.onS3EndpointUrlChange,
+                label = { Text("Endpoint URL (optional)") },
+                placeholder = { Text("https://minio.example.com") },
+                modifier = Modifier.fillMaxWidth(),
+                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+                colors =
+                    TextFieldDefaults.colors(
+                        focusedContainerColor = MaterialTheme.colorScheme.surface,
+                        unfocusedContainerColor = MaterialTheme.colorScheme.surface,
+                    ),
+            )
+
+            TextField(
+                value = state.s3Region,
+                onValueChange = actions.onS3RegionChange,
+                label = { Text("Region (optional)") },
+                placeholder = { Text("us-east-1") },
+                modifier = Modifier.fillMaxWidth(),
+                colors =
+                    TextFieldDefaults.colors(
+                        focusedContainerColor = MaterialTheme.colorScheme.surface,
+                        unfocusedContainerColor = MaterialTheme.colorScheme.surface,
+                    ),
+            )
+
+            TextField(
+                value = state.s3AccessKeyId,
+                onValueChange = actions.onS3AccessKeyIdChange,
+                label = { Text("Access Key ID") },
+                modifier = Modifier.fillMaxWidth(),
+                colors =
+                    TextFieldDefaults.colors(
+                        focusedContainerColor = MaterialTheme.colorScheme.surface,
+                        unfocusedContainerColor = MaterialTheme.colorScheme.surface,
+                    ),
+            )
+
+            TextField(
+                value = state.s3SecretAccessKey,
+                onValueChange = actions.onS3SecretAccessKeyChange,
+                label = { Text("Secret Access Key") },
+                modifier = Modifier.fillMaxWidth(),
+                visualTransformation = if (state.s3SecretVisible) VisualTransformation.None else PasswordVisualTransformation(),
+                trailingIcon = {
+                    IconButton(onClick = { actions.onS3SecretVisibleChange(!state.s3SecretVisible) }) {
+                        Icon(
+                            imageVector = if (state.s3SecretVisible) Icons.Default.VisibilityOff else Icons.Default.Visibility,
+                            contentDescription = if (state.s3SecretVisible) "Hide secret" else "Show secret",
+                        )
+                    }
+                },
+                colors =
+                    TextFieldDefaults.colors(
+                        focusedContainerColor = MaterialTheme.colorScheme.surface,
+                        unfocusedContainerColor = MaterialTheme.colorScheme.surface,
+                    ),
+            )
+        }
 
         TextField(
             value = state.encryptionSecret,

--- a/android/app/src/main/kotlin/com/brokenpip3/fatto/vm/SettingsViewModel.kt
+++ b/android/app/src/main/kotlin/com/brokenpip3/fatto/vm/SettingsViewModel.kt
@@ -3,6 +3,7 @@ package com.brokenpip3.fatto.vm
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import com.brokenpip3.fatto.data.SettingsRepository
+import com.brokenpip3.fatto.data.SyncType
 import com.brokenpip3.fatto.data.TaskrcImportPreview
 import com.brokenpip3.fatto.data.TaskrcImporter
 import com.brokenpip3.fatto.data.model.TaskContext
@@ -11,6 +12,9 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 
 class SettingsViewModel(private val repository: SettingsRepository) : ViewModel() {
+    private val _syncType = MutableStateFlow(SyncType.SERVER)
+    val syncType = _syncType.asStateFlow()
+
     private val _syncUrl = MutableStateFlow("")
     val syncUrl = _syncUrl.asStateFlow()
 
@@ -19,6 +23,21 @@ class SettingsViewModel(private val repository: SettingsRepository) : ViewModel(
 
     private val _encryptionSecret = MutableStateFlow("")
     val encryptionSecret = _encryptionSecret.asStateFlow()
+
+    private val _s3Bucket = MutableStateFlow("")
+    val s3Bucket = _s3Bucket.asStateFlow()
+
+    private val _s3Region = MutableStateFlow("")
+    val s3Region = _s3Region.asStateFlow()
+
+    private val _s3EndpointUrl = MutableStateFlow("")
+    val s3EndpointUrl = _s3EndpointUrl.asStateFlow()
+
+    private val _s3AccessKeyId = MutableStateFlow("")
+    val s3AccessKeyId = _s3AccessKeyId.asStateFlow()
+
+    private val _s3SecretAccessKey = MutableStateFlow("")
+    val s3SecretAccessKey = _s3SecretAccessKey.asStateFlow()
 
     private val _showCompleted = MutableStateFlow(true)
     val showCompleted = _showCompleted.asStateFlow()
@@ -82,6 +101,8 @@ class SettingsViewModel(private val repository: SettingsRepository) : ViewModel(
     }
 
     private fun load() {
+        _syncType.value = repository.getSyncType()
+
         val creds = repository.getCredentials()
         if (creds != null) {
             _syncUrl.value = creds.url
@@ -90,6 +111,21 @@ class SettingsViewModel(private val repository: SettingsRepository) : ViewModel(
             Log.d("SettingsViewModel", "Loaded credentials from repository")
         } else {
             Log.d("SettingsViewModel", "No credentials found in repository")
+        }
+
+        val s3Creds = repository.getS3Credentials()
+        if (s3Creds != null) {
+            _s3Bucket.value = s3Creds.bucket
+            _s3Region.value = s3Creds.region ?: ""
+            _s3EndpointUrl.value = s3Creds.endpointUrl ?: ""
+            _s3AccessKeyId.value = s3Creds.accessKeyId
+            _s3SecretAccessKey.value = s3Creds.secretAccessKey
+            // For S3 the encryption secret lives alongside the S3 credentials; surface
+            // it in the shared field so the user can review/edit it.
+            if (_syncType.value == SyncType.S3) {
+                _encryptionSecret.value = s3Creds.secret
+            }
+            Log.d("SettingsViewModel", "Loaded S3 credentials from repository")
         }
         _showCompleted.value = repository.getShowCompleted()
         _showInternalTags.value = repository.getShowInternalTags()
@@ -109,8 +145,32 @@ class SettingsViewModel(private val repository: SettingsRepository) : ViewModel(
         _themeMode.value = repository.getThemeMode()
     }
 
+    fun onSyncTypeChange(value: SyncType) {
+        _syncType.value = value
+    }
+
     fun onUrlChange(value: String) {
         _syncUrl.value = value
+    }
+
+    fun onS3BucketChange(value: String) {
+        _s3Bucket.value = value
+    }
+
+    fun onS3RegionChange(value: String) {
+        _s3Region.value = value
+    }
+
+    fun onS3EndpointUrlChange(value: String) {
+        _s3EndpointUrl.value = value
+    }
+
+    fun onS3AccessKeyIdChange(value: String) {
+        _s3AccessKeyId.value = value
+    }
+
+    fun onS3SecretAccessKeyChange(value: String) {
+        _s3SecretAccessKey.value = value
     }
 
     fun onClientIdChange(value: String) {
@@ -234,21 +294,76 @@ class SettingsViewModel(private val repository: SettingsRepository) : ViewModel(
         _taskrcImportPreview.value = preview
     }
 
-    fun save() {
-        val url = _syncUrl.value.trim()
-        val clientIdValue = _clientId.value.trim()
+    /**
+     * Persist the sync configuration. The active backend (sync type) is only
+     * persisted together with a complete set of credentials, so an incomplete
+     * form can never switch the app to a backend that has no usable credentials.
+     *
+     * @return true if the settings were saved, false if required fields are missing.
+     */
+    fun save(): Boolean {
+        val type = _syncType.value
         val secret = _encryptionSecret.value.trim()
 
-        Log.d("SettingsViewModel", "Saving settings to repository")
-        repository.saveCredentials(url, clientIdValue, secret)
+        val saved =
+            when (type) {
+                SyncType.S3 -> saveS3Credentials(secret)
+                SyncType.SERVER -> saveServerCredentials(secret)
+            }
+        if (saved) {
+            repository.setSyncType(type)
+        }
+        return saved
+    }
+
+    private fun saveS3Credentials(secret: String): Boolean {
+        val bucket = _s3Bucket.value.trim()
+        val accessKeyId = _s3AccessKeyId.value.trim()
+        val secretAccessKey = _s3SecretAccessKey.value.trim()
+        if (bucket.isEmpty() || accessKeyId.isEmpty() || secretAccessKey.isEmpty() || secret.isEmpty()) {
+            Log.d("SettingsViewModel", "Not saving: incomplete S3 credentials")
+            return false
+        }
+        Log.d("SettingsViewModel", "Saving S3 settings to repository")
+        repository.saveS3Credentials(
+            bucket = bucket,
+            region = _s3Region.value.trim().ifEmpty { null },
+            endpointUrl = _s3EndpointUrl.value.trim().ifEmpty { null },
+            accessKeyId = accessKeyId,
+            secretAccessKey = secretAccessKey,
+            secret = secret,
+        )
+        return true
+    }
+
+    private fun saveServerCredentials(secret: String): Boolean {
+        val url = _syncUrl.value.trim()
+        val clientId = _clientId.value.trim()
+        if (url.isEmpty() || clientId.isEmpty() || secret.isEmpty()) {
+            Log.d("SettingsViewModel", "Not saving: incomplete server credentials")
+            return false
+        }
+        Log.d("SettingsViewModel", "Saving server settings to repository")
+        repository.saveCredentials(
+            url = url,
+            clientId = clientId,
+            secret = secret,
+        )
+        return true
     }
 
     fun clear() {
         Log.d("SettingsViewModel", "Clearing settings")
         repository.clearCredentials()
+        _syncType.value = SyncType.SERVER
         _syncUrl.value = ""
         _clientId.value = ""
         _encryptionSecret.value = ""
+        _s3Bucket.value = ""
+        _s3Region.value = ""
+        _s3EndpointUrl.value = ""
+        _s3AccessKeyId.value = ""
+        _s3SecretAccessKey.value = ""
         _showCompleted.value = true
         repository.setShowCompleted(true)
         _confirmActions.value = true

--- a/android/app/src/main/kotlin/com/brokenpip3/fatto/vm/TaskViewModel.kt
+++ b/android/app/src/main/kotlin/com/brokenpip3/fatto/vm/TaskViewModel.kt
@@ -2,6 +2,7 @@ package com.brokenpip3.fatto.vm
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.brokenpip3.fatto.data.DateTimeUtils
 import com.brokenpip3.fatto.data.TaskContextMatcher
 import com.brokenpip3.fatto.data.TaskRepository
 import com.brokenpip3.fatto.data.model.Annotation
@@ -200,7 +201,7 @@ class TaskViewModel(private val repository: TaskRepository) : ViewModel() {
         ) { tasks, allTasks, hideBlocked, now ->
             tasks.filter { task ->
                 if (task.status != TaskStatus.PENDING) return@filter false
-                if (task.wait != null && Instant.parse(task.wait).isAfter(now)) return@filter false
+                if (DateTimeUtils.parseToInstant(task.wait)?.isAfter(now) == true) return@filter false
 
                 if (hideBlocked && task.isBlocked) {
                     val blockingDeps =
@@ -209,7 +210,7 @@ class TaskViewModel(private val repository: TaskRepository) : ViewModel() {
                         }.filter { it.status != TaskStatus.COMPLETED }
 
                     if (blockingDeps.isNotEmpty()) {
-                        val hasDepsWait = blockingDeps.all { it.wait != null && Instant.parse(it.wait).isAfter(now) }
+                        val hasDepsWait = blockingDeps.all { DateTimeUtils.parseToInstant(it.wait)?.isAfter(now) == true }
                         if (hasDepsWait) return@filter false
                     }
                 }
@@ -226,7 +227,7 @@ class TaskViewModel(private val repository: TaskRepository) : ViewModel() {
         ) { tasks, showWaiting, now ->
             if (!showWaiting) return@combine emptyList()
             tasks.filter { task ->
-                task.status == TaskStatus.PENDING && task.wait != null && Instant.parse(task.wait).isAfter(now)
+                task.status == TaskStatus.PENDING && DateTimeUtils.parseToInstant(task.wait)?.isAfter(now) == true
             }
         }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 

--- a/android/app/src/main/kotlin/com/brokenpip3/fatto/worker/SyncWorker.kt
+++ b/android/app/src/main/kotlin/com/brokenpip3/fatto/worker/SyncWorker.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import androidx.work.CoroutineWorker
 import androidx.work.WorkerParameters
 import com.brokenpip3.fatto.data.SettingsRepositoryImpl
+import com.brokenpip3.fatto.data.Syncer
 import uniffi.taskchampion_android.ReplicaWrapper
 import java.io.File
 
@@ -14,14 +15,14 @@ class SyncWorker(
 ) : CoroutineWorker(appContext, workerParams) {
     override suspend fun doWork(): Result {
         val settingsRepository = SettingsRepositoryImpl(applicationContext)
-        val creds = settingsRepository.getCredentials() ?: return Result.success()
+        if (!settingsRepository.hasCredentials()) return Result.success()
 
         return try {
             val path = File(applicationContext.filesDir, "taskchampion").absolutePath
             val replica = ReplicaWrapper.newOnDisk(path)
 
             Log.d("SyncWorker", "Starting background sync...")
-            replica.sync(creds.url, creds.clientId, creds.secret)
+            Syncer.sync(replica, settingsRepository)
             Log.d("SyncWorker", "Background sync completed successfully.")
 
             Result.success()

--- a/android/app/src/test/kotlin/com/brokenpip3/fatto/SettingsViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/brokenpip3/fatto/SettingsViewModelTest.kt
@@ -1,7 +1,9 @@
 package com.brokenpip3.fatto
 
+import com.brokenpip3.fatto.data.S3Credentials
 import com.brokenpip3.fatto.data.SettingsRepository
 import com.brokenpip3.fatto.data.SyncCredentials
+import com.brokenpip3.fatto.data.SyncType
 import com.brokenpip3.fatto.data.TaskrcImportPreview
 import com.brokenpip3.fatto.data.TaskrcImportResultType
 import com.brokenpip3.fatto.data.model.TaskContext
@@ -10,8 +12,10 @@ import com.brokenpip3.fatto.vm.SettingsViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertNotNull
 import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.util.Calendar
 
@@ -53,6 +57,58 @@ class SettingsViewModelTest {
         viewModel.applyTaskrcImport()
 
         assertEquals(preview, repository.appliedPreview)
+    }
+
+    @Test
+    fun `save with incomplete s3 fields does not switch backend`() {
+        val repository = FakeSettingsRepository()
+        val viewModel = SettingsViewModel(repository)
+
+        viewModel.onSyncTypeChange(SyncType.S3)
+        viewModel.onS3BucketChange("my-bucket")
+        // access key, secret access key and encryption secret left empty
+
+        assertFalse(viewModel.save())
+        assertEquals(SyncType.SERVER, repository.getSyncType())
+        assertNull(repository.getS3Credentials())
+    }
+
+    @Test
+    fun `save with complete s3 fields persists credentials and backend`() {
+        val repository = FakeSettingsRepository()
+        val viewModel = SettingsViewModel(repository)
+
+        viewModel.onSyncTypeChange(SyncType.S3)
+        viewModel.onS3BucketChange("my-bucket")
+        viewModel.onS3AccessKeyIdChange("access-key")
+        viewModel.onS3SecretAccessKeyChange("secret-key")
+        viewModel.onSecretChange("encryption-secret")
+
+        assertTrue(viewModel.save())
+        assertEquals(SyncType.S3, repository.getSyncType())
+        assertEquals(
+            S3Credentials(
+                bucket = "my-bucket",
+                region = null,
+                endpointUrl = null,
+                accessKeyId = "access-key",
+                secretAccessKey = "secret-key",
+                secret = "encryption-secret",
+            ),
+            repository.getS3Credentials(),
+        )
+    }
+
+    @Test
+    fun `save with incomplete server fields does not persist`() {
+        val repository = FakeSettingsRepository()
+        val viewModel = SettingsViewModel(repository)
+
+        viewModel.onUrlChange("http://example.com:8080")
+        // client id and encryption secret left empty
+
+        assertFalse(viewModel.save())
+        assertNull(repository.getCredentials())
     }
 
     private class FakeSettingsRepository : SettingsRepository {
@@ -115,17 +171,50 @@ class SettingsViewModelTest {
             sortDirection.value = value
         }
 
-        override fun getCredentials(): SyncCredentials? = null
+        private var syncType: SyncType = SyncType.SERVER
+        private var credentials: SyncCredentials? = null
+        private var s3Credentials: S3Credentials? = null
+
+        override fun getSyncType(): SyncType = syncType
+
+        override fun setSyncType(type: SyncType) {
+            syncType = type
+        }
+
+        override fun getCredentials(): SyncCredentials? = credentials
 
         override fun saveCredentials(
             url: String,
             clientId: String,
             secret: String,
-        ) = Unit
+        ) {
+            credentials = SyncCredentials(url, clientId, secret)
+        }
 
-        override fun clearCredentials() = Unit
+        override fun getS3Credentials(): S3Credentials? = s3Credentials
 
-        override fun hasCredentials(): Boolean = false
+        override fun saveS3Credentials(
+            bucket: String,
+            region: String?,
+            endpointUrl: String?,
+            accessKeyId: String,
+            secretAccessKey: String,
+            secret: String,
+        ) {
+            s3Credentials = S3Credentials(bucket, region, endpointUrl, accessKeyId, secretAccessKey, secret)
+        }
+
+        override fun clearCredentials() {
+            credentials = null
+            s3Credentials = null
+            syncType = SyncType.SERVER
+        }
+
+        override fun hasCredentials(): Boolean =
+            when (syncType) {
+                SyncType.S3 -> s3Credentials != null
+                SyncType.SERVER -> credentials != null
+            }
 
         override fun getShowCompleted(): Boolean = showCompleted.value
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,34 @@
 services:
+  # Local S3-compatible endpoint for the s3 sync backend integration tests.
+  # Pinned to the last community release of minio (the image is no longer
+  # updated upstream but remains available and is plenty for a test endpoint).
+  minio:
+    image: minio/minio:RELEASE.2025-09-07T16-13-09Z
+    ports:
+      - "9000:9000"
+    environment:
+      - "MINIO_ROOT_USER=minioadmin"
+      - "MINIO_ROOT_PASSWORD=minioadmin"
+    command: server /data
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 2s
+      timeout: 5s
+      retries: 15
+
+  # One-shot job that creates the bucket used by the s3 integration tests.
+  minio-init:
+    image: minio/mc:RELEASE.2025-08-13T08-35-41Z
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      sh -c "
+      mc alias set local http://minio:9000 minioadmin minioadmin &&
+      mc mb --ignore-existing local/fatto-tasks &&
+      echo 'S3 bucket ready.'
+      "
+
   tss:
     image: ghcr.io/gothenburgbitfactory/taskchampion-sync-server:0.7.1
     ports:

--- a/justfile
+++ b/justfile
@@ -144,12 +144,16 @@ test-android:
     adb shell pm grant com.brokenpip3.fatto android.permission.POST_NOTIFICATIONS || true
     cd android && ./gradlew connectedDebugAndroidTest
 
-# run rust integration tests against local tss
+# run rust integration tests against local tss and minio
 test-integration:
     cd rust/taskchampion-android && \
     TASKCHAMPION_SYNC_URL=http://localhost:8080 \
     TASKCHAMPION_CLIENT_ID=768d9f09-accd-406d-8685-7b977b83d5c6 \
     TASKCHAMPION_SYNC_SECRET=foobar \
+    TASKCHAMPION_S3_ENDPOINT=http://localhost:9000 \
+    TASKCHAMPION_S3_BUCKET=fatto-tasks \
+    TASKCHAMPION_S3_ACCESS_KEY_ID=minioadmin \
+    TASKCHAMPION_S3_SECRET_ACCESS_KEY=minioadmin \
     cargo test --test integration -- --nocapture
 
 # format code

--- a/rust/taskchampion-android/Cargo.lock
+++ b/rust/taskchampion-android/Cargo.lock
@@ -2673,7 +2673,7 @@ dependencies = [
 
 [[package]]
 name = "taskchampion-android"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/rust/taskchampion-android/Cargo.toml
+++ b/rust/taskchampion-android/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "taskchampion-android"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 [lib]

--- a/rust/taskchampion-android/src/lib.rs
+++ b/rust/taskchampion-android/src/lib.rs
@@ -1,6 +1,7 @@
 use chrono::{DateTime, Utc};
 use std::str::FromStr;
 use std::sync::{Arc, Mutex};
+use taskchampion::server::AwsCredentials;
 use taskchampion::storage::inmemory::InMemoryStorage;
 use taskchampion::storage::sqlite::SqliteStorage;
 use taskchampion::storage::{AccessMode, Storage};
@@ -354,6 +355,49 @@ impl ReplicaWrapper {
             url: server_url,
             client_id,
             encryption_secret: secret.into_bytes(),
+        };
+        self.rt.block_on(async {
+            let mut server = config.into_server().await?;
+            replica.sync(&mut server, false).await
+        })?;
+        Ok(())
+    }
+
+    /// Sync with an AWS S3 or S3-compatible storage bucket (e.g. minio, Backblaze B2,
+    /// Garage). This mirrors taskchampion's `ServerConfig::Aws` cloud backend.
+    ///
+    /// `region` and `endpoint_url` are optional: leave `region` empty to use the AWS
+    /// default region, and set `endpoint_url` to the hostname of an S3-compatible
+    /// service. When an `endpoint_url` is provided the client switches to path-style
+    /// addressing, which is what most self-hosted S3-compatible services expect.
+    #[allow(clippy::too_many_arguments)]
+    pub fn sync_aws(
+        &self,
+        bucket: String,
+        region: Option<String>,
+        endpoint_url: Option<String>,
+        access_key_id: String,
+        secret_access_key: String,
+        encryption_secret: String,
+    ) -> Result<()> {
+        let mut replica = self.inner.lock().unwrap();
+
+        // Normalize empty optional strings coming across the FFI boundary to `None`.
+        let region = region.filter(|s| !s.is_empty());
+        let endpoint_url = endpoint_url.filter(|s| !s.is_empty());
+
+        let config = ServerConfig::Aws {
+            // S3-compatible endpoints generally require path-style addressing; real
+            // AWS S3 (no custom endpoint) keeps the default virtual-hosted style.
+            force_path_style: endpoint_url.is_some(),
+            region,
+            bucket,
+            endpoint_url,
+            credentials: AwsCredentials::AccessKey {
+                access_key_id,
+                secret_access_key,
+            },
+            encryption_secret: encryption_secret.into_bytes(),
         };
         self.rt.block_on(async {
             let mut server = config.into_server().await?;
@@ -972,6 +1016,23 @@ mod tests {
             "UDAs should contain 'custom_uda': {:?}",
             task_data.udas
         );
+    }
+
+    #[test]
+    fn test_sync_aws_invalid_bucket_errors_gracefully() {
+        // We can't reach a real bucket in unit tests, but syncing against a
+        // bogus endpoint must surface a TaskError rather than panic, exercising
+        // the ServerConfig::Aws construction path.
+        let wrapper = ReplicaWrapper::new_in_memory().unwrap();
+        let result = wrapper.sync_aws(
+            "fatto-nonexistent-bucket".into(),
+            None,
+            Some("http://127.0.0.1:1".into()),
+            "AKIAEXAMPLE".into(),
+            "secretkeyexample".into(),
+            "encryption-secret".into(),
+        );
+        assert!(result.is_err());
     }
 
     #[test]

--- a/rust/taskchampion-android/tests/integration.rs
+++ b/rust/taskchampion-android/tests/integration.rs
@@ -146,6 +146,74 @@ fn test_sync_conflict_integration() {
     assert_eq!(tasks1.len(), tasks2.len());
 }
 
+/// Connection details for the local S3-compatible endpoint (the `minio`
+/// service in docker-compose.yml). Returns (endpoint, bucket, access key id,
+/// secret access key, encryption secret).
+fn s3_test_config() -> (String, String, String, String, String) {
+    (
+        env::var("TASKCHAMPION_S3_ENDPOINT").unwrap_or_else(|_| "http://localhost:9000".into()),
+        env::var("TASKCHAMPION_S3_BUCKET").unwrap_or_else(|_| "fatto-tasks".into()),
+        env::var("TASKCHAMPION_S3_ACCESS_KEY_ID").unwrap_or_else(|_| "minioadmin".into()),
+        env::var("TASKCHAMPION_S3_SECRET_ACCESS_KEY").unwrap_or_else(|_| "minioadmin".into()),
+        env::var("TASKCHAMPION_S3_ENCRYPTION_SECRET")
+            .unwrap_or_else(|_| "s3-integration-secret".into()),
+    )
+}
+
+fn sync_aws_with_test_config(rep: &ReplicaWrapper) {
+    let (endpoint, bucket, access_key_id, secret_access_key, encryption_secret) = s3_test_config();
+    rep.sync_aws(
+        bucket,
+        None,
+        Some(endpoint),
+        access_key_id,
+        secret_access_key,
+        encryption_secret,
+    )
+    .unwrap();
+}
+
+// The whole S3 roundtrip lives in a single test: all replicas share one
+// bucket, so concurrently running tests would race on the same version chain.
+#[test]
+fn test_sync_aws_integration() {
+    // The bucket persists across test runs within a compose session, so tag
+    // the task with a unique marker.
+    let description = format!("S3 task {}", uuid::Uuid::new_v4());
+
+    // 1. Create first replica, add a task and push it to the bucket
+    let rep1 = ReplicaWrapper::new_in_memory().unwrap();
+    let task1 = rep1
+        .add_task(TaskAddProps {
+            description: description.clone(),
+            project: None,
+            tags: vec![],
+            wait: None,
+            due: None,
+            scheduled: None,
+            start: None,
+            priority: None,
+            dependencies: vec![],
+        })
+        .unwrap();
+    sync_aws_with_test_config(&rep1);
+
+    // 2. A fresh replica syncing against the same bucket sees the task
+    let rep2 = ReplicaWrapper::new_in_memory().unwrap();
+    sync_aws_with_test_config(&rep2);
+    let tasks2 = rep2.all_task_data().unwrap();
+    assert!(tasks2.iter().any(|t| t.description == description));
+
+    // 3. Complete the task in the second replica and propagate it back
+    rep2.update_task_status(task1.uuid.clone(), TaskStatus::Completed)
+        .unwrap();
+    sync_aws_with_test_config(&rep2);
+    sync_aws_with_test_config(&rep1);
+    let tasks1 = rep1.all_task_data().unwrap();
+    let task1_updated = tasks1.iter().find(|t| t.uuid == task1.uuid).unwrap();
+    assert_eq!(task1_updated.status, TaskStatus::Completed);
+}
+
 #[test]
 fn test_task_properties_integration() {
     let rep = ReplicaWrapper::new_in_memory().unwrap();


### PR DESCRIPTION
Summary

Fatto can currently only sync against a taskchampion-sync-server instance. This PR adds a second sync backend: AWS S3 and S3-compatible object storage (minio, Backblaze B2, Garage, etc.), exposing taskchampion's built-in ServerConfig::Aws cloud backend through the app. Users pick their backend in Settings, and all sync paths (manual, post-mutation, and the background worker) go through it.

What's included

Rust (taskchampion-android)
- New sync_aws(bucket, region, endpoint_url, access_key_id, secret_access_key, encryption_secret) on ReplicaWrapper, wrapping ServerConfig::Aws with AwsCredentials::AccessKey.
- region and endpoint_url are optional — an empty region falls back to the AWS default, and setting endpoint_url targets an S3-compatible service.
- When a custom endpoint_url is given, the client switches to path-style addressing (force_path_style), which self-hosted S3-compatible services generally require; real AWS S3 keeps virtual-hosted style.
- Added a unit test asserting a bogus endpoint surfaces a TaskError instead of panicking, exercising the config-construction path.

Android
- SyncType enum (server / s3) plus S3Credentials, persisted via the existing settings storage (getSyncType/setSyncType, getS3Credentials/saveS3Credentials).
- New Syncer object centralizes backend dispatch so manual sync, reactive post-mutation sync, and SyncWorker all behave identically. SyncWorker now uses hasCredentials() + Syncer.sync(...) instead of hardcoding the server path.
- Settings UI: a backend selector (Sync Server vs. S3 storage) and S3 credential fields — Bucket, Region, Endpoint URL (optional), Access Key ID, Secret Access Key, and encryption secret.

Bug fix (included)

Fixed a crash-on-launch that surfaced once real Taskwarrior data was synced in. The Rust layer serializes timestamps with chrono's to_rfc3339(), which renders UTC as +00:00, but TaskViewModel parsed wait with Instant.parse, which only accepts a Z suffix and throws DateTimeParseException on an offset. Any task carrying a wait/scheduled date killed the app during the activeTasks filter. Added a tolerant DateTimeUtils.parseToInstant() (accepts both Z and numeric offsets, returns null on failure) and routed the three parse sites through it.

Docs

- README: sync feature now mentions AWS S3 / S3-compatible storage.
- ROADMAP: S3 sync item checked off.

Testing

- ./gradlew :app:assembleDebug succeeds (debug APK builds).
- Rust unit test for the S3 error path added.
- Manually verified the app launches and filters tasks correctly with S3 sync configured and incoming +00:00-offset timestamps.