### PR TITLE
context support v1: simple task filterning and context management in settings screen

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -166,6 +166,7 @@ dependencies {
     testImplementation("junit:junit:4.13.2")
     testImplementation("io.mockk:mockk:1.14.11")
     testImplementation("io.mockk:mockk-agent-jvm:1.14.11")
+    testImplementation("org.json:json:20260522")
     testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.11.0")
     androidTestImplementation("androidx.test:rules:1.7.0")
     androidTestImplementation("androidx.test.ext:junit:1.3.0")

--- a/android/app/src/androidTest/kotlin/com/brokenpip3/fatto/ContextIntegrationTest.kt
+++ b/android/app/src/androidTest/kotlin/com/brokenpip3/fatto/ContextIntegrationTest.kt
@@ -1,0 +1,102 @@
+package com.brokenpip3.fatto
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.hasAnyAncestor
+import androidx.compose.ui.test.hasTestTag
+import androidx.compose.ui.test.hasText
+import androidx.compose.ui.test.junit4.createEmptyComposeRule
+import androidx.compose.ui.test.onNodeWithContentDescription
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import androidx.compose.ui.test.performTextClearance
+import androidx.compose.ui.test.performTextInput
+import androidx.compose.ui.test.waitUntilAtLeastOneExists
+import androidx.compose.ui.test.waitUntilDoesNotExist
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.rule.GrantPermissionRule
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+
+@OptIn(ExperimentalTestApi::class)
+@RunWith(AndroidJUnit4::class)
+class ContextIntegrationTest {
+    @get:Rule
+    val composeTestRule = createEmptyComposeRule()
+
+    @get:Rule
+    val permissionRule: GrantPermissionRule = GrantPermissionRule.grant(android.Manifest.permission.POST_NOTIFICATIONS)
+
+    private lateinit var scenario: ActivityScenario<MainActivity>
+
+    @Before
+    fun clearState() {
+        clearAppState()
+        scenario = ActivityScenario.launch(MainActivity::class.java)
+    }
+
+    @After
+    fun closeScenario() {
+        if (::scenario.isInitialized) {
+            scenario.close()
+        }
+        clearAppState()
+    }
+
+    @Test
+    fun saveClearAndSelectContextFromTaskList() {
+        val suffix = System.currentTimeMillis()
+        val matchingTask = "Context alpha $suffix"
+        val hiddenTask = "Context beta $suffix"
+        val contextName = "Context $suffix"
+
+        createTask(matchingTask)
+        createTask(hiddenTask)
+
+        composeTestRule.onNodeWithContentDescription("Contexts").performClick()
+        composeTestRule.onNodeWithText("New context").performClick()
+        composeTestRule.onNodeWithText("Search").performTextInput(matchingTask)
+        composeTestRule.onNodeWithText("Save").performClick()
+        composeTestRule.onNodeWithText("Context name").performTextClearance()
+        composeTestRule.onNodeWithText("Context name").performTextInput(contextName)
+        composeTestRule.onNodeWithContentDescription("Confirm save context").performClick()
+
+        composeTestRule.waitUntilAtLeastOneExists(hasText("Context: $contextName"), 15000)
+        composeTestRule.waitUntilAtLeastOneExists(hasTaskListText(matchingTask), 15000)
+        composeTestRule.waitUntilDoesNotExist(hasTaskListText(hiddenTask), 15000)
+
+        composeTestRule.onNodeWithContentDescription("Clear context").performClick()
+        composeTestRule.waitUntilDoesNotExist(hasText("Context: $contextName"), 15000)
+        composeTestRule.waitUntilAtLeastOneExists(hasTaskListText(hiddenTask), 15000)
+
+        composeTestRule.onNodeWithContentDescription("Contexts").performClick()
+        composeTestRule.onNodeWithText(contextName).performClick()
+
+        composeTestRule.waitUntilAtLeastOneExists(hasText("Context: $contextName"), 15000)
+        composeTestRule.waitUntilAtLeastOneExists(hasTaskListText(matchingTask), 15000)
+        composeTestRule.waitUntilDoesNotExist(hasTaskListText(hiddenTask), 15000)
+    }
+
+    private fun createTask(description: String) {
+        composeTestRule.onNodeWithContentDescription("Add Task").performClick()
+        composeTestRule.onNodeWithText("Description").performTextInput(description)
+        composeTestRule.onNodeWithText("Create").performClick()
+        composeTestRule.waitUntilDoesNotExist(hasText("New Task"), 10000)
+        composeTestRule.waitUntilAtLeastOneExists(hasTaskListText(description), 15000)
+    }
+
+    private fun hasTaskListText(text: String) = hasText(text) and hasAnyAncestor(hasTestTag("TaskList"))
+
+    private fun clearAppState() {
+        val context = androidx.test.platform.app.InstrumentationRegistry.getInstrumentation().targetContext
+        val dbDir = File(context.filesDir, "taskchampion")
+        if (dbDir.exists()) {
+            dbDir.deleteRecursively()
+        }
+        context.deleteSharedPreferences("sync_settings")
+    }
+}

--- a/android/app/src/main/kotlin/com/brokenpip3/fatto/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/brokenpip3/fatto/MainActivity.kt
@@ -200,6 +200,7 @@ class MainActivity : ComponentActivity() {
                                 viewModel = taskViewModel,
                                 onAddTaskClick = { showAddTaskDialog = true },
                                 onTaskClick = { selectedTask = it },
+                                onManageContexts = { navController.navigate("settings") },
                                 confirmActions = confirmActions,
                             )
 
@@ -265,7 +266,14 @@ class MainActivity : ComponentActivity() {
                             )
                         }
                         composable("settings") {
-                            SettingsScreen(viewModel = settingsViewModel)
+                            val availableTags by taskViewModel.availableTags.collectAsState()
+                            val hierarchicalProjects by taskViewModel.hierarchicalProjects.collectAsState()
+
+                            SettingsScreen(
+                                viewModel = settingsViewModel,
+                                availableProjects = hierarchicalProjects.map { it.fullName },
+                                availableTags = availableTags,
+                            )
                         }
                     }
                 }

--- a/android/app/src/main/kotlin/com/brokenpip3/fatto/data/SettingsRepository.kt
+++ b/android/app/src/main/kotlin/com/brokenpip3/fatto/data/SettingsRepository.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import java.util.Calendar
+import java.util.Locale
 
 data class SyncCredentials(
     val url: String,
@@ -448,7 +449,7 @@ class SettingsRepositoryImpl(context: Context) : SettingsRepository {
     override fun saveTaskContext(context: TaskContext) {
         val updated =
             (getTaskContexts().filterNot { it.id == context.id } + context)
-                .sortedBy { it.name.lowercase() }
+                .sortedBy { it.name.lowercase(Locale.ROOT) }
         sharedPreferences
             ?.edit()
             ?.putString("task_contexts", TaskContextCodec.encode(updated))

--- a/android/app/src/main/kotlin/com/brokenpip3/fatto/data/SettingsRepository.kt
+++ b/android/app/src/main/kotlin/com/brokenpip3/fatto/data/SettingsRepository.kt
@@ -5,6 +5,7 @@ import android.content.SharedPreferences
 import android.util.Log
 import androidx.security.crypto.EncryptedSharedPreferences
 import androidx.security.crypto.MasterKey
+import com.brokenpip3.fatto.data.model.TaskContext
 import com.brokenpip3.fatto.ui.theme.ThemeMode
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -37,6 +38,8 @@ interface SettingsRepository {
     val showPriorityBadge: StateFlow<Boolean>
     val showUrgencyBar: StateFlow<Boolean>
     val themeMode: StateFlow<ThemeMode>
+    val taskContexts: StateFlow<List<TaskContext>>
+    val activeTaskContextId: StateFlow<String?>
 
     fun getFirstDayOfWeek(): Int
 
@@ -121,6 +124,16 @@ interface SettingsRepository {
     fun getThemeMode(): ThemeMode
 
     fun setThemeMode(value: ThemeMode)
+
+    fun getTaskContexts(): List<TaskContext>
+
+    fun saveTaskContext(context: TaskContext)
+
+    fun deleteTaskContext(id: String)
+
+    fun getActiveTaskContextId(): String?
+
+    fun setActiveTaskContextId(id: String?)
 }
 
 @Suppress("TooManyFunctions")
@@ -200,6 +213,12 @@ class SettingsRepositoryImpl(context: Context) : SettingsRepository {
 
     private val _themeMode = MutableStateFlow(getThemeMode())
     override val themeMode: StateFlow<ThemeMode> = _themeMode.asStateFlow()
+
+    private val _taskContexts = MutableStateFlow(getTaskContexts())
+    override val taskContexts: StateFlow<List<TaskContext>> = _taskContexts.asStateFlow()
+
+    private val _activeTaskContextId = MutableStateFlow(getActiveTaskContextId())
+    override val activeTaskContextId: StateFlow<String?> = _activeTaskContextId.asStateFlow()
 
     override fun getFirstDayOfWeek(): Int {
         return sharedPreferences?.getInt("first_day_of_week", Calendar.MONDAY) ?: Calendar.MONDAY
@@ -420,6 +439,46 @@ class SettingsRepositoryImpl(context: Context) : SettingsRepository {
     override fun setThemeMode(value: ThemeMode) {
         themeModeSettings.set(value)
         _themeMode.value = value
+    }
+
+    override fun getTaskContexts(): List<TaskContext> {
+        return TaskContextCodec.decode(sharedPreferences?.getString("task_contexts", null))
+    }
+
+    override fun saveTaskContext(context: TaskContext) {
+        val updated =
+            (getTaskContexts().filterNot { it.id == context.id } + context)
+                .sortedBy { it.name.lowercase() }
+        sharedPreferences
+            ?.edit()
+            ?.putString("task_contexts", TaskContextCodec.encode(updated))
+            ?.apply()
+        _taskContexts.value = updated
+    }
+
+    override fun deleteTaskContext(id: String) {
+        val updated = getTaskContexts().filterNot { it.id == id }
+        sharedPreferences
+            ?.edit()
+            ?.putString("task_contexts", TaskContextCodec.encode(updated))
+            ?.apply()
+        _taskContexts.value = updated
+        if (_activeTaskContextId.value == id) {
+            setActiveTaskContextId(null)
+        }
+    }
+
+    override fun getActiveTaskContextId(): String? {
+        return sharedPreferences?.getString("active_task_context_id", null)
+    }
+
+    override fun setActiveTaskContextId(id: String?) {
+        if (id == null) {
+            sharedPreferences?.edit()?.remove("active_task_context_id")?.apply()
+        } else {
+            sharedPreferences?.edit()?.putString("active_task_context_id", id)?.apply()
+        }
+        _activeTaskContextId.value = id
     }
 }
 

--- a/android/app/src/main/kotlin/com/brokenpip3/fatto/data/TaskContextCodec.kt
+++ b/android/app/src/main/kotlin/com/brokenpip3/fatto/data/TaskContextCodec.kt
@@ -1,0 +1,52 @@
+package com.brokenpip3.fatto.data
+
+import android.util.Log
+import com.brokenpip3.fatto.data.model.TaskContext
+import org.json.JSONArray
+import org.json.JSONObject
+
+object TaskContextCodec {
+    fun encode(contexts: List<TaskContext>): String {
+        val array = JSONArray()
+        contexts.forEach { context ->
+            val tags = JSONArray()
+            context.tags.sorted().forEach { tags.put(it) }
+            array.put(
+                JSONObject()
+                    .put("id", context.id)
+                    .put("name", context.name)
+                    .put("descriptionQuery", context.descriptionQuery)
+                    .put("project", context.project)
+                    .put("tags", tags),
+            )
+        }
+        return array.toString()
+    }
+
+    fun decode(value: String?): List<TaskContext> {
+        if (value.isNullOrBlank()) return emptyList()
+        return try {
+            val array = JSONArray(value)
+            List(array.length()) { index ->
+                val item = array.getJSONObject(index)
+                val tagsArray = item.optJSONArray("tags") ?: JSONArray()
+                val tags = List(tagsArray.length()) { tagIndex -> tagsArray.getString(tagIndex) }.toSet()
+                TaskContext(
+                    id = item.optString("id"),
+                    name = item.optString("name"),
+                    descriptionQuery = item.optString("descriptionQuery"),
+                    project =
+                        if (item.isNull("project")) {
+                            null
+                        } else {
+                            item.optString("project").takeIf { it.isNotBlank() }
+                        },
+                    tags = tags,
+                )
+            }.filter { it.id.isNotBlank() && it.name.isNotBlank() }
+        } catch (e: Exception) {
+            Log.e("TaskContextCodec", "Failed to decode task contexts", e)
+            emptyList()
+        }
+    }
+}

--- a/android/app/src/main/kotlin/com/brokenpip3/fatto/data/TaskContextMatcher.kt
+++ b/android/app/src/main/kotlin/com/brokenpip3/fatto/data/TaskContextMatcher.kt
@@ -1,0 +1,24 @@
+package com.brokenpip3.fatto.data
+
+import com.brokenpip3.fatto.data.model.Task
+import com.brokenpip3.fatto.data.model.TaskContext
+
+object TaskContextMatcher {
+    fun matches(
+        task: Task,
+        context: TaskContext?,
+    ): Boolean {
+        if (context == null) return true
+
+        val matchesDescription =
+            context.descriptionQuery.isBlank() ||
+                task.description.contains(context.descriptionQuery, ignoreCase = true)
+        val matchesProject =
+            context.project.isNullOrBlank() ||
+                task.project == context.project ||
+                task.project?.startsWith("${context.project}.") == true
+        val matchesTags = context.tags.isEmpty() || task.tags.containsAll(context.tags)
+
+        return matchesDescription && matchesProject && matchesTags
+    }
+}

--- a/android/app/src/main/kotlin/com/brokenpip3/fatto/data/TaskRepository.kt
+++ b/android/app/src/main/kotlin/com/brokenpip3/fatto/data/TaskRepository.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.util.Log
 import com.brokenpip3.fatto.data.model.Annotation
 import com.brokenpip3.fatto.data.model.Task
+import com.brokenpip3.fatto.data.model.TaskContext
 import com.brokenpip3.fatto.data.model.toModel
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -35,6 +36,8 @@ class TaskRepository(
     val sortDirection: StateFlow<String> = settingsRepository.sortDirection
     val showPriorityBadge: StateFlow<Boolean> = settingsRepository.showPriorityBadge
     val showUrgencyBar: StateFlow<Boolean> = settingsRepository.showUrgencyBar
+    val taskContexts: StateFlow<List<TaskContext>> = settingsRepository.taskContexts
+    val activeTaskContextId: StateFlow<String?> = settingsRepository.activeTaskContextId
 
     fun setSortOrder(order: String) {
         settingsRepository.setSortOrder(order)
@@ -42,6 +45,18 @@ class TaskRepository(
 
     fun setSortDirection(direction: String) {
         settingsRepository.setSortDirection(direction)
+    }
+
+    fun saveTaskContext(context: TaskContext) {
+        settingsRepository.saveTaskContext(context)
+    }
+
+    fun deleteTaskContext(id: String) {
+        settingsRepository.deleteTaskContext(id)
+    }
+
+    fun setActiveTaskContextId(id: String?) {
+        settingsRepository.setActiveTaskContextId(id)
     }
 
     suspend fun init() =

--- a/android/app/src/main/kotlin/com/brokenpip3/fatto/data/model/TaskContext.kt
+++ b/android/app/src/main/kotlin/com/brokenpip3/fatto/data/model/TaskContext.kt
@@ -1,0 +1,21 @@
+package com.brokenpip3.fatto.data.model
+
+import java.util.UUID
+
+data class TaskContext(
+    val id: String = UUID.randomUUID().toString(),
+    val name: String,
+    val descriptionQuery: String = "",
+    val project: String? = null,
+    val tags: Set<String> = emptySet(),
+) {
+    fun summary(): String {
+        val parts =
+            buildList {
+                if (descriptionQuery.isNotBlank()) add("Search: $descriptionQuery")
+                if (!project.isNullOrBlank()) add("Project: $project")
+                if (tags.isNotEmpty()) add("Tags: ${tags.sorted().joinToString(", ")}")
+            }
+        return if (parts.isEmpty()) "All tasks" else parts.joinToString(" · ")
+    }
+}

--- a/android/app/src/main/kotlin/com/brokenpip3/fatto/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/kotlin/com/brokenpip3/fatto/ui/settings/SettingsScreen.kt
@@ -3,6 +3,8 @@ package com.brokenpip3.fatto.ui.settings
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -39,6 +41,7 @@ import androidx.compose.material3.Snackbar
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.material3.TopAppBar
@@ -56,13 +59,20 @@ import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
+import com.brokenpip3.fatto.data.model.TaskContext
+import com.brokenpip3.fatto.ui.tasklist.TaskFilterBuilderSheet
+import com.brokenpip3.fatto.ui.tasklist.TaskFilterState
 import com.brokenpip3.fatto.ui.theme.ThemeMode
 import com.brokenpip3.fatto.vm.SettingsViewModel
 import kotlinx.coroutines.launch
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalLayoutApi::class, ExperimentalMaterial3Api::class)
 @Composable
-fun SettingsScreen(viewModel: SettingsViewModel) {
+fun SettingsScreen(
+    viewModel: SettingsViewModel,
+    availableProjects: List<String>,
+    availableTags: Set<String>,
+) {
     val syncUrl by viewModel.syncUrl.collectAsState()
     val clientId by viewModel.clientId.collectAsState()
     val encryptionSecret by viewModel.encryptionSecret.collectAsState()
@@ -82,8 +92,11 @@ fun SettingsScreen(viewModel: SettingsViewModel) {
     val showPriorityBadge by viewModel.showPriorityBadge.collectAsState()
     val showUrgencyBar by viewModel.showUrgencyBar.collectAsState()
     val themeMode by viewModel.themeMode.collectAsState()
+    val taskContexts by viewModel.taskContexts.collectAsState()
+    val activeTaskContextId by viewModel.activeTaskContextId.collectAsState()
 
     var secretVisible by remember { mutableStateOf(false) }
+    var editingContext by remember { mutableStateOf<TaskContext?>(null) }
     val snackbarHostState = remember { SnackbarHostState() }
     val scope = rememberCoroutineScope()
     val focusManager = LocalFocusManager.current
@@ -391,6 +404,61 @@ fun SettingsScreen(viewModel: SettingsViewModel) {
             Spacer(modifier = Modifier.height(8.dp))
 
             Text(
+                text = "Contexts",
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.primary,
+            )
+
+            if (taskContexts.isEmpty()) {
+                Text(
+                    text = "No saved contexts",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            } else {
+                taskContexts.forEach { context ->
+                    Card(
+                        modifier = Modifier.fillMaxWidth(),
+                        colors =
+                            CardDefaults.cardColors(
+                                containerColor = MaterialTheme.colorScheme.surface,
+                            ),
+                    ) {
+                        Column(
+                            modifier = Modifier.padding(12.dp),
+                            verticalArrangement = Arrangement.spacedBy(6.dp),
+                        ) {
+                            Text(
+                                text = context.name,
+                                style = MaterialTheme.typography.titleSmall,
+                            )
+                            Text(
+                                text = context.summary(),
+                                style = MaterialTheme.typography.bodySmall,
+                                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                            )
+                            FlowRow(
+                                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                verticalArrangement = Arrangement.spacedBy(4.dp),
+                            ) {
+                                TextButton(onClick = { viewModel.setActiveTaskContext(context.id) }) {
+                                    Text(if (activeTaskContextId == context.id) "Active" else "Use")
+                                }
+                                TextButton(onClick = { editingContext = context }) {
+                                    Text("Edit")
+                                }
+                                TextButton(onClick = { viewModel.deleteTaskContext(context.id) }) {
+                                    Text("Delete", color = MaterialTheme.colorScheme.error)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Text(
                 text = "Visualization",
                 style = MaterialTheme.typography.titleMedium,
                 color = MaterialTheme.colorScheme.primary,
@@ -499,6 +567,24 @@ fun SettingsScreen(viewModel: SettingsViewModel) {
                             .padding(start = 8.dp),
                 )
             }
+        }
+
+        editingContext?.let { context ->
+            TaskFilterBuilderSheet(
+                initialState = TaskFilterState.fromContext(context),
+                availableProjects = availableProjects,
+                availableTags = availableTags,
+                contextName = context.name,
+                onDismiss = { editingContext = null },
+                onApply = { filter ->
+                    viewModel.saveTaskContext(filter.toContext(name = context.name, id = context.id))
+                    editingContext = null
+                },
+                onSaveContext = { name, filter ->
+                    viewModel.saveTaskContext(filter.toContext(name = name, id = context.id))
+                    editingContext = null
+                },
+            )
         }
     }
 }

--- a/android/app/src/main/kotlin/com/brokenpip3/fatto/ui/tasklist/ContextSelectorMenu.kt
+++ b/android/app/src/main/kotlin/com/brokenpip3/fatto/ui/tasklist/ContextSelectorMenu.kt
@@ -1,0 +1,74 @@
+package com.brokenpip3.fatto.ui.tasklist
+
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Workspaces
+import androidx.compose.material3.DropdownMenu
+import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.brokenpip3.fatto.data.model.TaskContext
+
+@Composable
+fun ContextSelectorMenu(
+    contexts: List<TaskContext>,
+    activeContextId: String?,
+    expanded: Boolean,
+    onExpandedChange: (Boolean) -> Unit,
+    onContextSelected: (String?) -> Unit,
+    onCreateContext: () -> Unit,
+    onManageContexts: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    IconButton(onClick = { onExpandedChange(true) }, modifier = modifier) {
+        Icon(Icons.Default.Workspaces, contentDescription = "Contexts")
+    }
+    DropdownMenu(
+        expanded = expanded,
+        onDismissRequest = { onExpandedChange(false) },
+    ) {
+        DropdownMenuItem(
+            text = { Text("No context") },
+            onClick = {
+                onContextSelected(null)
+                onExpandedChange(false)
+            },
+            leadingIcon = {
+                if (activeContextId == null) {
+                    Icon(Icons.Default.Check, contentDescription = null)
+                }
+            },
+        )
+        contexts.forEach { context ->
+            DropdownMenuItem(
+                text = { Text(context.name) },
+                onClick = {
+                    onContextSelected(context.id)
+                    onExpandedChange(false)
+                },
+                leadingIcon = {
+                    if (activeContextId == context.id) {
+                        Icon(Icons.Default.Check, contentDescription = null)
+                    }
+                },
+            )
+        }
+        DropdownMenuItem(
+            text = { Text("New context") },
+            onClick = {
+                onCreateContext()
+                onExpandedChange(false)
+            },
+        )
+        DropdownMenuItem(
+            text = { Text("Manage contexts") },
+            onClick = {
+                onManageContexts()
+                onExpandedChange(false)
+            },
+        )
+    }
+}

--- a/android/app/src/main/kotlin/com/brokenpip3/fatto/ui/tasklist/TaskFilterBuilderSheet.kt
+++ b/android/app/src/main/kotlin/com/brokenpip3/fatto/ui/tasklist/TaskFilterBuilderSheet.kt
@@ -1,0 +1,284 @@
+package com.brokenpip3.fatto.ui.tasklist
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AccountTree
+import androidx.compose.material.icons.filled.Tag
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.semantics.contentDescription
+import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.unit.dp
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+fun TaskFilterBuilderSheet(
+    initialState: TaskFilterState,
+    availableProjects: List<String>,
+    availableTags: Set<String>,
+    contextName: String,
+    onDismiss: () -> Unit,
+    onApply: (TaskFilterState) -> Unit,
+    onSaveContext: (String, TaskFilterState) -> Unit,
+) {
+    var state by remember(initialState) { mutableStateOf(initialState) }
+    var projectQuery by remember(initialState.project) { mutableStateOf(initialState.project ?: "") }
+    var tagQuery by remember { mutableStateOf("") }
+    var projectExpanded by remember { mutableStateOf(false) }
+    var tagsExpanded by remember { mutableStateOf(false) }
+    var showNameDialog by remember { mutableStateOf(false) }
+    val scrollState = rememberScrollState()
+
+    val filteredProjects =
+        remember(projectQuery, availableProjects) {
+            if (projectQuery.isBlank()) {
+                availableProjects.sorted().take(12)
+            } else {
+                availableProjects
+                    .filter { it.contains(projectQuery, ignoreCase = true) && it != state.project }
+                    .sorted()
+                    .take(12)
+            }
+        }
+    val filteredTags =
+        remember(tagQuery, availableTags, state.tags) {
+            if (tagQuery.isBlank()) {
+                emptyList()
+            } else {
+                availableTags
+                    .filter { it.contains(tagQuery, ignoreCase = true) && !state.tags.contains(it) }
+                    .sorted()
+                    .take(12)
+            }
+        }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Filters") },
+        text = {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(12.dp),
+                modifier =
+                    Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = 520.dp)
+                        .verticalScroll(scrollState),
+            ) {
+                OutlinedTextField(
+                    value = state.descriptionQuery,
+                    onValueChange = { state = state.copy(descriptionQuery = it) },
+                    label = { Text("Search") },
+                    singleLine = true,
+                    modifier = Modifier.fillMaxWidth(),
+                )
+
+                AccordionSection(
+                    title = state.project?.let { "Project: $it" } ?: "Project",
+                    icon = Icons.Default.AccountTree,
+                    count = if (state.project == null) null else 1,
+                    expanded = projectExpanded,
+                    onToggle = { projectExpanded = !projectExpanded },
+                ) {
+                    OutlinedTextField(
+                        value = projectQuery,
+                        onValueChange = { projectQuery = it },
+                        label = { Text("Find project") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth(),
+                    )
+                    FlowRow(
+                        horizontalArrangement = Arrangement.spacedBy(8.dp),
+                        verticalArrangement = Arrangement.spacedBy(8.dp),
+                        modifier = Modifier.padding(top = 8.dp),
+                    ) {
+                        SuggestionChip(
+                            label = "Any project",
+                            onClick = {
+                                state = state.copy(project = null)
+                                projectQuery = ""
+                            },
+                        )
+                        filteredProjects.forEach { project ->
+                            SuggestionChip(
+                                label = project,
+                                onClick = {
+                                    state = state.copy(project = project)
+                                    projectQuery = project
+                                },
+                            )
+                        }
+                    }
+                }
+
+                AccordionSection(
+                    title = if (state.tags.isEmpty()) "Tags" else "Tags: ${state.tags.size}",
+                    icon = Icons.Default.Tag,
+                    count = state.tags.size.takeIf { it > 0 },
+                    expanded = tagsExpanded,
+                    onToggle = { tagsExpanded = !tagsExpanded },
+                ) {
+                    if (state.tags.isNotEmpty()) {
+                        FlowRow(
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                            modifier = Modifier.padding(bottom = 8.dp),
+                        ) {
+                            state.tags.sorted().forEach { tag ->
+                                TagChip(tag = tag, onRemove = { state = state.copy(tags = state.tags - tag) })
+                            }
+                        }
+                    }
+                    OutlinedTextField(
+                        value = tagQuery,
+                        onValueChange = { tagQuery = it },
+                        label = { Text("Add tag") },
+                        singleLine = true,
+                        modifier = Modifier.fillMaxWidth(),
+                        trailingIcon = {
+                            TextButton(
+                                onClick = {
+                                    val tag = tagQuery.trim()
+                                    if (tag.isNotBlank()) {
+                                        state = state.copy(tags = state.tags + tag)
+                                        tagQuery = ""
+                                    }
+                                },
+                            ) {
+                                Text("Add")
+                            }
+                        },
+                    )
+                    if (filteredTags.isNotEmpty()) {
+                        FlowRow(
+                            horizontalArrangement = Arrangement.spacedBy(8.dp),
+                            verticalArrangement = Arrangement.spacedBy(8.dp),
+                            modifier = Modifier.padding(top = 8.dp),
+                        ) {
+                            filteredTags.forEach { tag ->
+                                SuggestionChip(
+                                    label = tag,
+                                    onClick = {
+                                        state = state.copy(tags = state.tags + tag)
+                                        tagQuery = ""
+                                    },
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        confirmButton = {
+            FlowRow(
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.padding(start = 8.dp),
+            ) {
+                TextButton(
+                    onClick = {
+                        state = TaskFilterState()
+                        projectQuery = ""
+                        tagQuery = ""
+                    },
+                ) {
+                    Text("Clear")
+                }
+                TextButton(onClick = { showNameDialog = true }) {
+                    Text("Save")
+                }
+                Button(
+                    onClick = { onApply(state) },
+                    shape = RoundedCornerShape(8.dp),
+                ) {
+                    Text("Apply")
+                }
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        },
+    )
+
+    if (showNameDialog) {
+        SaveContextDialog(
+            initialName = contextName,
+            filterState = state,
+            onDismiss = { showNameDialog = false },
+            onSave = { name ->
+                onSaveContext(name, state)
+                showNameDialog = false
+            },
+        )
+    }
+}
+
+@Composable
+private fun SaveContextDialog(
+    initialName: String,
+    filterState: TaskFilterState,
+    onDismiss: () -> Unit,
+    onSave: (String) -> Unit,
+) {
+    var name by remember(initialName, filterState) { mutableStateOf(initialName.ifBlank { filterState.defaultContextName() }) }
+
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = { Text("Save context") },
+        text = {
+            OutlinedTextField(
+                value = name,
+                onValueChange = { name = it },
+                label = { Text("Context name") },
+                singleLine = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+        },
+        confirmButton = {
+            Button(
+                onClick = { onSave(name.trim()) },
+                enabled = name.isNotBlank(),
+                modifier =
+                    Modifier.semantics {
+                        contentDescription = "Confirm save context"
+                    },
+                shape = RoundedCornerShape(8.dp),
+            ) {
+                Text("Save")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text("Cancel")
+            }
+        },
+    )
+}
+
+private fun TaskFilterState.defaultContextName(): String {
+    return when {
+        project != null -> "Project $project"
+        tags.isNotEmpty() -> "Tags ${tags.sorted().joinToString(", ")}"
+        descriptionQuery.isNotBlank() -> descriptionQuery.trim().take(32)
+        else -> "Context"
+    }
+}

--- a/android/app/src/main/kotlin/com/brokenpip3/fatto/ui/tasklist/TaskFilterState.kt
+++ b/android/app/src/main/kotlin/com/brokenpip3/fatto/ui/tasklist/TaskFilterState.kt
@@ -1,0 +1,31 @@
+package com.brokenpip3.fatto.ui.tasklist
+
+import com.brokenpip3.fatto.data.model.TaskContext
+import java.util.UUID
+
+data class TaskFilterState(
+    val descriptionQuery: String = "",
+    val project: String? = null,
+    val tags: Set<String> = emptySet(),
+) {
+    fun toContext(
+        name: String,
+        id: String? = null,
+    ): TaskContext =
+        TaskContext(
+            id = id ?: UUID.randomUUID().toString(),
+            name = name.trim(),
+            descriptionQuery = descriptionQuery.trim(),
+            project = project?.trim()?.takeIf { it.isNotBlank() },
+            tags = tags,
+        )
+
+    companion object {
+        fun fromContext(context: TaskContext): TaskFilterState =
+            TaskFilterState(
+                descriptionQuery = context.descriptionQuery,
+                project = context.project,
+                tags = context.tags,
+            )
+    }
+}

--- a/android/app/src/main/kotlin/com/brokenpip3/fatto/ui/tasklist/TaskListScreen.kt
+++ b/android/app/src/main/kotlin/com/brokenpip3/fatto/ui/tasklist/TaskListScreen.kt
@@ -82,6 +82,7 @@ import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import com.brokenpip3.fatto.data.model.INTERNAL_TAGS
 import com.brokenpip3.fatto.data.model.Task
+import com.brokenpip3.fatto.data.model.TaskContext
 import com.brokenpip3.fatto.ui.theme.toNordicColor
 import com.brokenpip3.fatto.vm.SortDirection
 import com.brokenpip3.fatto.vm.SortOrder
@@ -96,6 +97,7 @@ fun TaskListScreen(
     viewModel: TaskViewModel,
     onTaskClick: (Task) -> Unit,
     onAddTaskClick: () -> Unit,
+    onManageContexts: () -> Unit,
     confirmActions: Boolean,
 ) {
     val tasks by viewModel.activeTasks.collectAsState()
@@ -112,6 +114,10 @@ fun TaskListScreen(
     val syncStatusMessage by viewModel.syncStatusMessage.collectAsState()
     val showPriorityBadge by viewModel.showPriorityBadge.collectAsState()
     val showUrgencyBar by viewModel.showUrgencyBar.collectAsState()
+    val contexts by viewModel.taskContexts.collectAsState()
+    val activeContextId by viewModel.activeTaskContextId.collectAsState()
+    val activeContext by viewModel.activeTaskContext.collectAsState()
+    val availableProjects by viewModel.hierarchicalProjects.collectAsState()
 
     val maxUrgency =
         maxOf(
@@ -122,6 +128,8 @@ fun TaskListScreen(
 
     var showFilters by remember { mutableStateOf(false) }
     var showSortMenu by remember { mutableStateOf(false) }
+    var showContextMenu by remember { mutableStateOf(false) }
+    var showFilterBuilder by remember { mutableStateOf(false) }
     var showCompleted by remember { mutableStateOf(false) }
     var showWaiting by remember { mutableStateOf(false) }
 
@@ -245,6 +253,17 @@ fun TaskListScreen(
                             modifier = Modifier.weight(1f),
                         )
 
+                        Box {
+                            ContextSelectorMenu(
+                                contexts = contexts,
+                                activeContextId = activeContextId,
+                                expanded = showContextMenu,
+                                onExpandedChange = { showContextMenu = it },
+                                onContextSelected = viewModel::setActiveTaskContextId,
+                                onCreateContext = { showFilterBuilder = true },
+                                onManageContexts = onManageContexts,
+                            )
+                        }
                         IconButton(onClick = { showFilters = !showFilters }) {
                             Icon(Icons.Default.FilterList, contentDescription = "Toggle Filters")
                         }
@@ -290,7 +309,12 @@ fun TaskListScreen(
                     }
 
                     AnimatedVisibility(
-                        visible = showFilters || searchQuery.isNotEmpty() || selectedTags.isNotEmpty() || activeProject != null,
+                        visible =
+                            showFilters ||
+                                searchQuery.isNotEmpty() ||
+                                selectedTags.isNotEmpty() ||
+                                activeProject != null ||
+                                activeContext != null,
                     ) {
                         Column(
                             modifier = Modifier.padding(top = 16.dp),
@@ -306,17 +330,29 @@ fun TaskListScreen(
                                     style = MaterialTheme.typography.titleSmall,
                                     color = MaterialTheme.colorScheme.onSurfaceVariant,
                                 )
-                                if (searchQuery.isNotEmpty() || selectedTags.isNotEmpty() || activeProject != null) {
+                                Row(
+                                    horizontalArrangement = Arrangement.spacedBy(8.dp),
+                                    verticalAlignment = Alignment.CenterVertically,
+                                ) {
                                     TextButton(
-                                        onClick = { viewModel.clearFilters() },
+                                        onClick = { showFilterBuilder = true },
                                         contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
                                         modifier = Modifier.height(32.dp),
                                     ) {
-                                        Text(
-                                            "Clear All",
-                                            style = MaterialTheme.typography.labelSmall,
-                                            color = MaterialTheme.colorScheme.error,
-                                        )
+                                        Text("Build filter", style = MaterialTheme.typography.labelSmall)
+                                    }
+                                    if (searchQuery.isNotEmpty() || selectedTags.isNotEmpty() || activeProject != null) {
+                                        TextButton(
+                                            onClick = { viewModel.clearFilters() },
+                                            contentPadding = PaddingValues(horizontal = 8.dp, vertical = 4.dp),
+                                            modifier = Modifier.height(32.dp),
+                                        ) {
+                                            Text(
+                                                "Clear All",
+                                                style = MaterialTheme.typography.labelSmall,
+                                                color = MaterialTheme.colorScheme.error,
+                                            )
+                                        }
                                     }
                                 }
                             }
@@ -346,32 +382,8 @@ fun TaskListScreen(
                                 },
                             )
 
-                            AnimatedVisibility(visible = textFieldValue.text.isEmpty()) {
-                                Row(
-                                    modifier = Modifier.fillMaxWidth(),
-                                    horizontalArrangement = Arrangement.spacedBy(8.dp),
-                                    verticalAlignment = Alignment.CenterVertically,
-                                ) {
-                                    Text(
-                                        "Tip:",
-                                        style = MaterialTheme.typography.labelSmall,
-                                        color = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.7f),
-                                    )
-                                    SuggestionChip(
-                                        onClick = {
-                                            val prefix = if (textFieldValue.text.isEmpty() || textFieldValue.text.endsWith(" ")) "" else " "
-                                            viewModel.onSearchQueryChange("${textFieldValue.text}${prefix}project:")
-                                        },
-                                        label = "project:xxx",
-                                    )
-                                    SuggestionChip(
-                                        onClick = {
-                                            val prefix = if (textFieldValue.text.isEmpty() || textFieldValue.text.endsWith(" ")) "" else " "
-                                            viewModel.onSearchQueryChange("${textFieldValue.text}${prefix}tags:")
-                                        },
-                                        label = "tags:xxx,yyy",
-                                    )
-                                }
+                            activeContext?.let { context ->
+                                ContextChip(context = context, onClear = { viewModel.setActiveTaskContextId(null) })
                             }
 
                             if (activeProject != null) {
@@ -592,6 +604,36 @@ fun TaskListScreen(
                 )
             }
 
+            if (showFilterBuilder) {
+                TaskFilterBuilderSheet(
+                    initialState =
+                        TaskFilterState(
+                            descriptionQuery = searchQuery,
+                            project = activeProject,
+                            tags = selectedTags,
+                        ),
+                    availableProjects = availableProjects.map { it.fullName },
+                    availableTags = availableTags,
+                    contextName = "",
+                    onDismiss = { showFilterBuilder = false },
+                    onApply = { filter ->
+                        viewModel.onSearchQueryChange(filter.descriptionQuery)
+                        viewModel.clearProject()
+                        filter.project?.let { viewModel.setActiveProject(it) }
+                        viewModel.clearTags()
+                        filter.tags.forEach { viewModel.toggleTag(it) }
+                        showFilterBuilder = false
+                    },
+                    onSaveContext = { name, filter ->
+                        val context = filter.toContext(name)
+                        viewModel.clearFilters()
+                        viewModel.saveTaskContext(context)
+                        viewModel.setActiveTaskContextId(context.id)
+                        showFilterBuilder = false
+                    },
+                )
+            }
+
             if (taskToDelete != null) {
                 androidx.compose.material3.AlertDialog(
                     onDismissRequest = { taskToDelete = null },
@@ -614,6 +656,40 @@ fun TaskListScreen(
                     },
                 )
             }
+        }
+    }
+}
+
+@Composable
+private fun ContextChip(
+    context: TaskContext,
+    onClear: () -> Unit,
+) {
+    Surface(
+        onClick = onClear,
+        modifier =
+            Modifier.semantics {
+                contentDescription = "Clear context"
+            },
+        color = MaterialTheme.colorScheme.primaryContainer,
+        shape = RoundedCornerShape(16.dp),
+    ) {
+        Row(
+            modifier = Modifier.padding(horizontal = 12.dp, vertical = 6.dp),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(6.dp),
+        ) {
+            Text(
+                "Context: ${context.name}",
+                style = MaterialTheme.typography.labelMedium,
+                color = MaterialTheme.colorScheme.onPrimaryContainer,
+            )
+            Icon(
+                Icons.Default.Close,
+                contentDescription = null,
+                modifier = Modifier.size(16.dp),
+                tint = MaterialTheme.colorScheme.onPrimaryContainer,
+            )
         }
     }
 }

--- a/android/app/src/main/kotlin/com/brokenpip3/fatto/vm/SettingsViewModel.kt
+++ b/android/app/src/main/kotlin/com/brokenpip3/fatto/vm/SettingsViewModel.kt
@@ -3,6 +3,7 @@ package com.brokenpip3.fatto.vm
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import com.brokenpip3.fatto.data.SettingsRepository
+import com.brokenpip3.fatto.data.model.TaskContext
 import com.brokenpip3.fatto.ui.theme.ThemeMode
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -64,6 +65,9 @@ class SettingsViewModel(private val repository: SettingsRepository) : ViewModel(
 
     private val _themeMode = MutableStateFlow(ThemeMode.SYSTEM)
     val themeMode = _themeMode.asStateFlow()
+
+    val taskContexts = repository.taskContexts
+    val activeTaskContextId = repository.activeTaskContextId
 
     init {
         load()
@@ -187,6 +191,18 @@ class SettingsViewModel(private val repository: SettingsRepository) : ViewModel(
     fun onThemeModeChange(value: ThemeMode) {
         _themeMode.value = value
         repository.setThemeMode(value)
+    }
+
+    fun saveTaskContext(context: TaskContext) {
+        repository.saveTaskContext(context)
+    }
+
+    fun deleteTaskContext(id: String) {
+        repository.deleteTaskContext(id)
+    }
+
+    fun setActiveTaskContext(id: String?) {
+        repository.setActiveTaskContextId(id)
     }
 
     fun save() {

--- a/android/app/src/main/kotlin/com/brokenpip3/fatto/vm/TaskViewModel.kt
+++ b/android/app/src/main/kotlin/com/brokenpip3/fatto/vm/TaskViewModel.kt
@@ -2,10 +2,12 @@ package com.brokenpip3.fatto.vm
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.brokenpip3.fatto.data.TaskContextMatcher
 import com.brokenpip3.fatto.data.TaskRepository
 import com.brokenpip3.fatto.data.model.Annotation
 import com.brokenpip3.fatto.data.model.INTERNAL_TAGS
 import com.brokenpip3.fatto.data.model.Task
+import com.brokenpip3.fatto.data.model.TaskContext
 import com.brokenpip3.fatto.data.model.isSynthetic
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableSharedFlow
@@ -53,6 +55,13 @@ data class ProjectNode(
 
 data class Breadcrumb(val name: String, val fullPath: String?)
 
+private data class TaskListFilterState(
+    val project: String?,
+    val context: TaskContext?,
+    val sort: SortOrder,
+    val direction: SortDirection,
+)
+
 class TaskViewModel(private val repository: TaskRepository) : ViewModel() {
     private val _searchQuery = MutableStateFlow("")
     val searchQuery = _searchQuery.asStateFlow()
@@ -86,20 +95,36 @@ class TaskViewModel(private val repository: TaskRepository) : ViewModel() {
         )
     val sortDirection = _sortDirection.asStateFlow()
 
+    val taskContexts: StateFlow<List<TaskContext>> = repository.taskContexts
+    val activeTaskContextId: StateFlow<String?> = repository.activeTaskContextId
+    val activeTaskContext: StateFlow<TaskContext?> =
+        combine(taskContexts, activeTaskContextId) { contexts, activeId ->
+            contexts.firstOrNull { it.id == activeId }
+        }.stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), null)
+
+    private val taskListFilterState =
+        combine(
+            _activeProject,
+            activeTaskContext,
+            combine(_sortOrder, _sortDirection) { order, dir -> order to dir },
+        ) { project, context, (sort, direction) ->
+            TaskListFilterState(project, context, sort, direction)
+        }
+
     private val baseFilteredTasks: StateFlow<List<Task>> =
         combine(
             repository.tasks,
             _searchQuery,
             _selectedTags,
-            _activeProject,
-            combine(_sortOrder, _sortDirection) { order, dir -> order to dir },
-        ) { tasks, query, tags, project, (sort, direction) ->
+            taskListFilterState,
+        ) { tasks, query, tags, filters ->
             val parsed = com.brokenpip3.fatto.data.SearchParser.parse(query)
-            val effectiveProject = parsed.project ?: project
+            val effectiveProject = parsed.project ?: filters.project
             val effectiveTags = if (parsed.tags.isNotEmpty()) parsed.tags else tags
             val searchFilter = parsed.description
 
             tasks.filter { task ->
+                val matchesContext = TaskContextMatcher.matches(task, filters.context)
                 val matchesUuid = parsed.uuid == null || task.uuid == parsed.uuid
                 val matchesQuery = task.description.contains(searchFilter, ignoreCase = true)
                 val matchesTags = effectiveTags.isEmpty() || task.tags.intersect(effectiveTags).isNotEmpty()
@@ -107,10 +132,10 @@ class TaskViewModel(private val repository: TaskRepository) : ViewModel() {
                     effectiveProject == null ||
                         task.project == effectiveProject ||
                         task.project?.startsWith("$effectiveProject.") == true
-                matchesUuid && matchesQuery && matchesTags && matchesProject
+                matchesContext && matchesUuid && matchesQuery && matchesTags && matchesProject
             }.sortedWith { a, b ->
                 val result =
-                    when (sort) {
+                    when (filters.sort) {
                         SortOrder.DATE_CREATED -> (a.entry ?: "").compareTo(b.entry ?: "")
                         SortOrder.DUE_DATE -> {
                             val dueA = a.due ?: "9999"
@@ -142,7 +167,7 @@ class TaskViewModel(private val repository: TaskRepository) : ViewModel() {
                             schA.compareTo(schB)
                         }
                     }
-                if (direction == SortDirection.DESCENDING) -result else result
+                if (filters.direction == SortDirection.DESCENDING) -result else result
             }
         }.combine(repository.showCompleted) { tasks, showCompleted ->
             if (showCompleted) tasks else tasks.filter { it.status != TaskStatus.COMPLETED }
@@ -353,6 +378,18 @@ class TaskViewModel(private val repository: TaskRepository) : ViewModel() {
         _searchQuery.value = ""
         _selectedTags.value = emptySet()
         _activeProject.value = null
+    }
+
+    fun saveTaskContext(context: TaskContext) {
+        repository.saveTaskContext(context)
+    }
+
+    fun deleteTaskContext(id: String) {
+        repository.deleteTaskContext(id)
+    }
+
+    fun setActiveTaskContextId(id: String?) {
+        repository.setActiveTaskContextId(id)
     }
 
     fun setSortOrder(order: SortOrder) {

--- a/android/app/src/test/kotlin/com/brokenpip3/fatto/BlockedTasksFilterTest.kt
+++ b/android/app/src/test/kotlin/com/brokenpip3/fatto/BlockedTasksFilterTest.kt
@@ -41,6 +41,8 @@ class BlockedTasksFilterTest {
         every { repository.showWaitingTasks } returns MutableStateFlow(true)
         every { repository.sortOrder } returns MutableStateFlow("DATE_CREATED")
         every { repository.sortDirection } returns MutableStateFlow("")
+        every { repository.taskContexts } returns MutableStateFlow(emptyList())
+        every { repository.activeTaskContextId } returns MutableStateFlow(null)
     }
 
     @After

--- a/android/app/src/test/kotlin/com/brokenpip3/fatto/TaskContextCodecTest.kt
+++ b/android/app/src/test/kotlin/com/brokenpip3/fatto/TaskContextCodecTest.kt
@@ -1,0 +1,55 @@
+package com.brokenpip3.fatto
+
+import com.brokenpip3.fatto.data.TaskContextCodec
+import com.brokenpip3.fatto.data.model.TaskContext
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class TaskContextCodecTest {
+    @Test
+    fun `round trips contexts`() {
+        val contexts =
+            listOf(
+                TaskContext(
+                    id = "work-id",
+                    name = "Work",
+                    descriptionQuery = "call",
+                    project = "Work.Mobile",
+                    tags = setOf("office", "urgent"),
+                ),
+            )
+
+        val decoded = TaskContextCodec.decode(TaskContextCodec.encode(contexts))
+
+        assertEquals(contexts, decoded)
+    }
+
+    @Test
+    fun `round trips project named null`() {
+        val contexts =
+            listOf(
+                TaskContext(
+                    id = "null-project-id",
+                    name = "Null Project",
+                    project = "null",
+                ),
+            )
+
+        val decoded = TaskContextCodec.decode(TaskContextCodec.encode(contexts))
+
+        assertEquals(contexts, decoded)
+    }
+
+    @Test
+    fun `corrupted json returns empty list`() {
+        assertTrue(TaskContextCodec.decode("not-json").isEmpty())
+    }
+
+    @Test
+    fun `missing optional fields decode as empty filters`() {
+        val decoded = TaskContextCodec.decode("""[{"id":"id","name":"Inbox"}]""")
+
+        assertEquals(listOf(TaskContext(id = "id", name = "Inbox")), decoded)
+    }
+}

--- a/android/app/src/test/kotlin/com/brokenpip3/fatto/TaskContextMatcherTest.kt
+++ b/android/app/src/test/kotlin/com/brokenpip3/fatto/TaskContextMatcherTest.kt
@@ -1,0 +1,65 @@
+package com.brokenpip3.fatto
+
+import com.brokenpip3.fatto.data.TaskContextMatcher
+import com.brokenpip3.fatto.data.model.Task
+import com.brokenpip3.fatto.data.model.TaskContext
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import uniffi.taskchampion_android.TaskStatus
+
+class TaskContextMatcherTest {
+    @Test
+    fun `empty context matches every task`() {
+        assertTrue(TaskContextMatcher.matches(task(), TaskContext(name = "All")))
+    }
+
+    @Test
+    fun `description query matches case insensitively`() {
+        val context = TaskContext(name = "Calls", descriptionQuery = "CALL")
+
+        assertTrue(TaskContextMatcher.matches(task(description = "Call bank"), context))
+        assertFalse(TaskContextMatcher.matches(task(description = "Buy milk"), context))
+    }
+
+    @Test
+    fun `project matches exact project and subprojects`() {
+        val context = TaskContext(name = "Work", project = "Work")
+
+        assertTrue(TaskContextMatcher.matches(task(project = "Work"), context))
+        assertTrue(TaskContextMatcher.matches(task(project = "Work.Mobile"), context))
+        assertFalse(TaskContextMatcher.matches(task(project = "Home"), context))
+    }
+
+    @Test
+    fun `all context tags must be present`() {
+        val context = TaskContext(name = "Office", tags = setOf("office", "urgent"))
+
+        assertTrue(TaskContextMatcher.matches(task(tags = listOf("office", "urgent", "email")), context))
+        assertFalse(TaskContextMatcher.matches(task(tags = listOf("office")), context))
+    }
+
+    private fun task(
+        description: String = "task",
+        project: String? = null,
+        tags: List<String> = emptyList(),
+    ): Task =
+        Task(
+            uuid = "uuid",
+            description = description,
+            status = TaskStatus.PENDING,
+            tags = tags,
+            project = project,
+            entry = null,
+            wait = null,
+            due = null,
+            scheduled = null,
+            start = null,
+            priority = null,
+            urgency = 0f,
+            isBlocked = false,
+            isBlocking = false,
+            dependencies = emptyList(),
+            udas = emptyMap(),
+        )
+}

--- a/android/app/src/test/kotlin/com/brokenpip3/fatto/TaskContextViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/brokenpip3/fatto/TaskContextViewModelTest.kt
@@ -1,0 +1,156 @@
+package com.brokenpip3.fatto
+
+import com.brokenpip3.fatto.data.TaskRepository
+import com.brokenpip3.fatto.data.model.Task
+import com.brokenpip3.fatto.data.model.TaskContext
+import com.brokenpip3.fatto.vm.TaskViewModel
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Before
+import org.junit.Test
+import uniffi.taskchampion_android.TaskStatus
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TaskContextViewModelTest {
+    private val testDispatcher = StandardTestDispatcher()
+    private val repository = mockk<TaskRepository>(relaxed = true)
+    private val tasksFlow = MutableStateFlow<List<Task>>(emptyList())
+    private val contextsFlow = MutableStateFlow<List<TaskContext>>(emptyList())
+    private val activeContextIdFlow = MutableStateFlow<String?>(null)
+
+    @Before
+    fun setup() {
+        Dispatchers.setMain(testDispatcher)
+        every { repository.tasks } returns tasksFlow
+        every { repository.showCompleted } returns MutableStateFlow(false)
+        every { repository.hideBlockedTasksWaiting } returns MutableStateFlow(false)
+        every { repository.showWaitingTasks } returns MutableStateFlow(true)
+        every { repository.sortOrder } returns MutableStateFlow("DATE_CREATED")
+        every { repository.sortDirection } returns MutableStateFlow("")
+        every { repository.taskContexts } returns contextsFlow
+        every { repository.activeTaskContextId } returns activeContextIdFlow
+    }
+
+    @After
+    fun tearDown() {
+        Dispatchers.resetMain()
+    }
+
+    @Test
+    fun `active context filters active tasks`() =
+        runTest {
+            val context = TaskContext(id = "work", name = "Work", project = "Work", tags = setOf("office"))
+            contextsFlow.value = listOf(context)
+            activeContextIdFlow.value = context.id
+            tasksFlow.value =
+                listOf(
+                    task(uuid = "match", description = "Call client", project = "Work.Mobile", tags = listOf("office")),
+                    task(uuid = "wrong-project", description = "Call plumber", project = "Home", tags = listOf("office")),
+                    task(uuid = "wrong-tag", description = "Call vendor", project = "Work", tags = listOf("remote")),
+                )
+            val viewModel = TaskViewModel(repository)
+
+            val job = launch { viewModel.activeTasks.collect {} }
+            advanceUntilIdle()
+
+            assertEquals(listOf("match"), viewModel.activeTasks.value.map { it.uuid })
+            job.cancel()
+        }
+
+    @Test
+    fun `active context combines with normal search`() =
+        runTest {
+            val context = TaskContext(id = "calls", name = "Calls", project = "Work")
+            contextsFlow.value = listOf(context)
+            activeContextIdFlow.value = context.id
+            tasksFlow.value =
+                listOf(
+                    task(uuid = "call", description = "Call client", project = "Work"),
+                    task(uuid = "email", description = "Email client", project = "Work"),
+                    task(uuid = "home", description = "Call plumber", project = "Home"),
+                )
+            val viewModel = TaskViewModel(repository)
+
+            viewModel.onSearchQueryChange("call")
+            val job = launch { viewModel.activeTasks.collect {} }
+            advanceUntilIdle()
+
+            assertEquals(listOf("call"), viewModel.activeTasks.value.map { it.uuid })
+            job.cancel()
+        }
+
+    @Test
+    fun `active context exposes selected context`() =
+        runTest {
+            val context = TaskContext(id = "work", name = "Work")
+            contextsFlow.value = listOf(context)
+            activeContextIdFlow.value = context.id
+            val viewModel = TaskViewModel(repository)
+
+            val job = launch { viewModel.activeTaskContext.collect {} }
+            advanceUntilIdle()
+
+            assertEquals(context, viewModel.activeTaskContext.value)
+
+            activeContextIdFlow.value = "missing"
+            advanceUntilIdle()
+
+            assertNull(viewModel.activeTaskContext.value)
+            job.cancel()
+        }
+
+    @Test
+    fun `context actions delegate to repository`() {
+        val context = TaskContext(id = "work", name = "Work")
+        val viewModel = TaskViewModel(repository)
+
+        viewModel.saveTaskContext(context)
+        viewModel.deleteTaskContext(context.id)
+        viewModel.setActiveTaskContextId(context.id)
+        viewModel.setActiveTaskContextId(null)
+
+        verify { repository.saveTaskContext(context) }
+        verify { repository.deleteTaskContext(context.id) }
+        verify { repository.setActiveTaskContextId(context.id) }
+        verify { repository.setActiveTaskContextId(null) }
+    }
+
+    private fun task(
+        uuid: String,
+        description: String,
+        project: String? = null,
+        tags: List<String> = emptyList(),
+    ): Task =
+        Task(
+            uuid = uuid,
+            description = description,
+            status = TaskStatus.PENDING,
+            tags = tags,
+            project = project,
+            entry = "2026-01-01T00:00:00Z",
+            wait = null,
+            due = null,
+            scheduled = null,
+            start = null,
+            priority = null,
+            urgency = 0f,
+            isBlocked = false,
+            isBlocking = false,
+            dependencies = emptyList(),
+            udas = emptyMap(),
+        )
+}

--- a/android/app/src/test/kotlin/com/brokenpip3/fatto/TaskSortTest.kt
+++ b/android/app/src/test/kotlin/com/brokenpip3/fatto/TaskSortTest.kt
@@ -37,6 +37,8 @@ class TaskSortTest {
         every { repository.showWaitingTasks } returns MutableStateFlow(true)
         every { repository.sortOrder } returns MutableStateFlow("DATE_CREATED")
         every { repository.sortDirection } returns MutableStateFlow("")
+        every { repository.taskContexts } returns MutableStateFlow(emptyList())
+        every { repository.activeTaskContextId } returns MutableStateFlow(null)
     }
 
     @After

--- a/android/app/src/test/kotlin/com/brokenpip3/fatto/WaitingTasksFilterTest.kt
+++ b/android/app/src/test/kotlin/com/brokenpip3/fatto/WaitingTasksFilterTest.kt
@@ -42,6 +42,8 @@ class WaitingTasksFilterTest {
         every { repository.showWaitingTasks } returns showWaitingTasksFlow
         every { repository.sortOrder } returns MutableStateFlow("DATE_CREATED")
         every { repository.sortDirection } returns MutableStateFlow("")
+        every { repository.taskContexts } returns MutableStateFlow(emptyList())
+        every { repository.activeTaskContextId } returns MutableStateFlow(null)
     }
 
     @After


### PR DESCRIPTION
this is the first version, an initial contexts support with bare minimum features.
We can:
- create a context
- save it
- edit (inside settings)
- delete (inside settings)
- list (inside settings)

atm there is no support for also filtering with the context the tags, project and calendar view (and filtering notifications)

refer to https://github.com/brokenpip3/fatto/issues/27