### PR TITLE
fix: validate s3 sync settings and explain s3 errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,28 @@ You can download the latest apk from the [releases](https://github.com/brokenpip
 
 By time to time we also release beta versions, you can test it without interfering with the stable version, the stable version is a different app from an android perspective, so you can keep both or only use the stable one.
 
+## S3 sync
+
+Settings → Sync → *S3 storage* syncs directly with a bucket, with no server in between.
+
+| Field | AWS S3 | S3-compatible service (minio, Garage, ...) |
+| --- | --- | --- |
+| Bucket | the bucket name, e.g. `my-tasks` | same |
+| Endpoint URL | leave empty | required, with scheme: `https://minio.example.com` |
+| Region | the region the bucket was created in, e.g. `eu-west-2` (empty means `us-east-1`) | whatever the service expects, often empty |
+| Access Key ID | 20 upper-case characters, e.g. `AKIAIOSFODNN7EXAMPLE` | the service's key |
+| Secret Access Key | 40 characters, e.g. `wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY` | the service's secret |
+| Encryption Secret | your passphrase; must match the one used on your other clients | same |
+
+The keys are used verbatim: no quotes around them, and no escaping of the `/` in the
+secret. The key needs `s3:GetObject`, `s3:PutObject`, `s3:DeleteObject` and
+`s3:ListBucket` on the bucket. Temporary credentials (`ASIA...`) are not supported,
+since they also require a session token.
+
+If a sync fails with `SignatureDoesNotMatch`, the access key ID or the secret access
+key does not match what the bucket expects: re-enter both, watching for characters
+added or changed by the keyboard while typing.
+
 ## Architecture
 
 The backend is built in Rust using the official [taskChampion](https://github.com/GothenburgBitFactory/taskchampion), which provides a robust and efficient way to manage tasks and sync with `taskchampion-sync` servers. The frontend is written in Kotlin using Jetpack Compose.

--- a/android/app/src/main/kotlin/com/brokenpip3/fatto/data/S3SettingsValidator.kt
+++ b/android/app/src/main/kotlin/com/brokenpip3/fatto/data/S3SettingsValidator.kt
@@ -1,0 +1,110 @@
+package com.brokenpip3.fatto.data
+
+/**
+ * Field-level checks for the S3 sync settings.
+ *
+ * S3 answers a mistyped key, a newline picked up while pasting and a misspelled
+ * region with the same opaque `SignatureDoesNotMatch` (or a long connection
+ * timeout), so the mistakes that can be recognized without a network round trip
+ * are reported while the user is still looking at the form.
+ *
+ * The rust wrapper repeats these checks in `sync_aws` so they also hold for
+ * credentials that never went through this screen; keep the two in sync.
+ */
+object S3SettingsValidator {
+    private const val MIN_BUCKET_LENGTH = 3
+    private const val MAX_BUCKET_LENGTH = 63
+    private val ACCESS_KEY_ID_LENGTH = 16..128
+    private const val SECRET_ACCESS_KEY_LENGTH = 40
+
+    private val BUCKET = Regex("^[a-z0-9][a-z0-9.-]*[a-z0-9]$")
+    private val ACCESS_KEY_ID = Regex("^[A-Z0-9]+$")
+    private val SECRET_ACCESS_KEY = Regex("^[A-Za-z0-9+/=]+$")
+
+    /** Region names are `<area>-<direction>-<number>`, e.g. `eu-west-2`. */
+    private val REGION = Regex("^[a-z]+(-[a-z]+)+-[0-9]+$")
+
+    /**
+     * @return a message naming the field to fix, or null when the settings can
+     *   be saved. Values are expected to be trimmed by the caller.
+     */
+    @Suppress("ReturnCount")
+    fun validate(
+        bucket: String,
+        region: String,
+        endpointUrl: String,
+        accessKeyId: String,
+        secretAccessKey: String,
+        encryptionSecret: String,
+    ): String? {
+        if (bucket.isEmpty()) return "Bucket is required"
+        if (accessKeyId.isEmpty()) return "Access key ID is required"
+        if (secretAccessKey.isEmpty()) return "Secret access key is required"
+        if (encryptionSecret.isEmpty()) return "Encryption secret is required"
+
+        validateBucket(bucket)?.let { return it }
+
+        if (accessKeyId.any { it.isWhitespace() }) {
+            return "Access key ID must not contain spaces or line breaks"
+        }
+        if (secretAccessKey.any { it.isWhitespace() }) {
+            return "Secret access key must not contain spaces or line breaks"
+        }
+
+        if (endpointUrl.isNotEmpty()) {
+            // An S3-compatible service: its credentials and regions are its own.
+            if (!endpointUrl.startsWith("http://") && !endpointUrl.startsWith("https://")) {
+                return "Endpoint URL must start with http:// or https:// (e.g. https://minio.example.com)"
+            }
+            return null
+        }
+
+        validateAwsAccessKeyId(accessKeyId)?.let { return it }
+        validateAwsSecretAccessKey(secretAccessKey)?.let { return it }
+        if (region.isNotEmpty() && !REGION.matches(region)) {
+            return "'$region' is not an AWS region name. Regions look like eu-west-2 or us-east-1. " +
+                "Leave the field empty to use us-east-1, or set an endpoint URL when using an " +
+                "S3-compatible service"
+        }
+        return null
+    }
+
+    private fun validateBucket(bucket: String): String? {
+        val valid =
+            bucket.length in MIN_BUCKET_LENGTH..MAX_BUCKET_LENGTH &&
+                BUCKET.matches(bucket) &&
+                !bucket.contains("..")
+        return if (valid) {
+            null
+        } else {
+            "Invalid bucket name '$bucket'. Bucket names must be $MIN_BUCKET_LENGTH-$MAX_BUCKET_LENGTH " +
+                "characters of lowercase letters, digits, dots and hyphens, and start and end with a " +
+                "letter or digit"
+        }
+    }
+
+    private fun validateAwsAccessKeyId(accessKeyId: String): String? =
+        when {
+            accessKeyId.length !in ACCESS_KEY_ID_LENGTH || !ACCESS_KEY_ID.matches(accessKeyId) ->
+                "Access key ID does not look like an AWS key: it should be " +
+                    "${ACCESS_KEY_ID_LENGTH.first}-${ACCESS_KEY_ID_LENGTH.last} upper-case letters and " +
+                    "digits, such as AKIAIOSFODNN7EXAMPLE. Check for stray quotes, backslashes or " +
+                    "characters added while typing"
+            // Temporary credentials also carry a session token, which taskchampion cannot use.
+            accessKeyId.startsWith("ASIA") ->
+                "This is a temporary AWS access key (ASIA...), which also requires a session " +
+                    "token. Use a long-lived IAM user key (AKIA...) instead"
+            else -> null
+        }
+
+    private fun validateAwsSecretAccessKey(secretAccessKey: String): String? =
+        if (secretAccessKey.length != SECRET_ACCESS_KEY_LENGTH ||
+            !SECRET_ACCESS_KEY.matches(secretAccessKey)
+        ) {
+            "Secret access key does not look like an AWS secret: it should be exactly " +
+                "$SECRET_ACCESS_KEY_LENGTH characters of letters, digits, '+', '/' and '='. " +
+                "Backslashes and quotes are not part of the key and must not be escaped or included"
+        } else {
+            null
+        }
+}

--- a/android/app/src/main/kotlin/com/brokenpip3/fatto/ui/settings/SettingsScreen.kt
+++ b/android/app/src/main/kotlin/com/brokenpip3/fatto/ui/settings/SettingsScreen.kt
@@ -67,6 +67,7 @@ import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.semantics.role
 import androidx.compose.ui.semantics.selected
 import androidx.compose.ui.semantics.semantics
+import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
@@ -81,6 +82,19 @@ import com.brokenpip3.fatto.ui.tasklist.TaskFilterState
 import com.brokenpip3.fatto.ui.theme.ThemeMode
 import com.brokenpip3.fatto.vm.SettingsViewModel
 import kotlinx.coroutines.launch
+
+/**
+ * Keyboard options for fields that must be stored exactly as entered.
+ *
+ * Auto-correction, word suggestions and automatic capitalization all rewrite
+ * what the user typed, and a credential altered that way is only reported by
+ * the server as an unexplained authentication failure.
+ */
+private val VerbatimKeyboard =
+    KeyboardOptions(
+        capitalization = KeyboardCapitalization.None,
+        autoCorrectEnabled = false,
+    )
 
 private enum class SettingsTab(
     val label: String,
@@ -105,6 +119,7 @@ private data class SyncSettingsSectionState(
     val s3AccessKeyId: String,
     val s3SecretAccessKey: String,
     val s3SecretVisible: Boolean,
+    val validationError: String?,
 )
 
 private data class SyncSettingsSectionActions(
@@ -195,6 +210,7 @@ fun SettingsScreen(
     val s3EndpointUrl by viewModel.s3EndpointUrl.collectAsState()
     val s3AccessKeyId by viewModel.s3AccessKeyId.collectAsState()
     val s3SecretAccessKey by viewModel.s3SecretAccessKey.collectAsState()
+    val syncSettingsError by viewModel.syncSettingsError.collectAsState()
     val showCompleted by viewModel.showCompleted.collectAsState()
     val showInternalTags by viewModel.showInternalTags.collectAsState()
     val showEmptyProjects by viewModel.showEmptyProjects.collectAsState()
@@ -239,7 +255,13 @@ fun SettingsScreen(
     val onSaveSyncSettings: () -> Unit = {
         val saved = viewModel.save()
         focusManager.clearFocus()
-        launchSnackbar(if (saved) "Settings saved" else "Fill in all required sync fields")
+        launchSnackbar(
+            if (saved) {
+                "Settings saved"
+            } else {
+                viewModel.syncSettingsError.value ?: "Fill in all required sync fields"
+            },
+        )
     }
     val onClearSyncSettings: () -> Unit = {
         viewModel.clear()
@@ -313,6 +335,7 @@ fun SettingsScreen(
                                     s3AccessKeyId = s3AccessKeyId,
                                     s3SecretAccessKey = s3SecretAccessKey,
                                     s3SecretVisible = s3SecretVisible,
+                                    validationError = syncSettingsError,
                                 ),
                             actions =
                                 SyncSettingsSectionActions(
@@ -566,7 +589,8 @@ private fun SyncSettingsSection(
                 label = { Text("Sync Server URL") },
                 placeholder = { Text("http://example.com:8080") },
                 modifier = Modifier.fillMaxWidth(),
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+                singleLine = true,
+                keyboardOptions = VerbatimKeyboard.copy(keyboardType = KeyboardType.Uri),
                 colors =
                     TextFieldDefaults.colors(
                         focusedContainerColor = MaterialTheme.colorScheme.surface,
@@ -580,6 +604,8 @@ private fun SyncSettingsSection(
                 label = { Text("Client ID (UUID)") },
                 placeholder = { Text("00000000-0000-0000-0000-000000000000") },
                 modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+                keyboardOptions = VerbatimKeyboard,
                 colors =
                     TextFieldDefaults.colors(
                         focusedContainerColor = MaterialTheme.colorScheme.surface,
@@ -593,6 +619,8 @@ private fun SyncSettingsSection(
                 label = { Text("Bucket") },
                 placeholder = { Text("my-tasks-bucket") },
                 modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+                keyboardOptions = VerbatimKeyboard,
                 colors =
                     TextFieldDefaults.colors(
                         focusedContainerColor = MaterialTheme.colorScheme.surface,
@@ -606,7 +634,8 @@ private fun SyncSettingsSection(
                 label = { Text("Endpoint URL (optional)") },
                 placeholder = { Text("https://minio.example.com") },
                 modifier = Modifier.fillMaxWidth(),
-                keyboardOptions = KeyboardOptions(keyboardType = KeyboardType.Uri),
+                singleLine = true,
+                keyboardOptions = VerbatimKeyboard.copy(keyboardType = KeyboardType.Uri),
                 colors =
                     TextFieldDefaults.colors(
                         focusedContainerColor = MaterialTheme.colorScheme.surface,
@@ -620,6 +649,8 @@ private fun SyncSettingsSection(
                 label = { Text("Region (optional)") },
                 placeholder = { Text("us-east-1") },
                 modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+                keyboardOptions = VerbatimKeyboard,
                 colors =
                     TextFieldDefaults.colors(
                         focusedContainerColor = MaterialTheme.colorScheme.surface,
@@ -631,7 +662,10 @@ private fun SyncSettingsSection(
                 value = state.s3AccessKeyId,
                 onValueChange = actions.onS3AccessKeyIdChange,
                 label = { Text("Access Key ID") },
+                placeholder = { Text("AKIAIOSFODNN7EXAMPLE") },
                 modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+                keyboardOptions = VerbatimKeyboard,
                 colors =
                     TextFieldDefaults.colors(
                         focusedContainerColor = MaterialTheme.colorScheme.surface,
@@ -644,6 +678,8 @@ private fun SyncSettingsSection(
                 onValueChange = actions.onS3SecretAccessKeyChange,
                 label = { Text("Secret Access Key") },
                 modifier = Modifier.fillMaxWidth(),
+                singleLine = true,
+                keyboardOptions = VerbatimKeyboard.copy(keyboardType = KeyboardType.Password),
                 visualTransformation = if (state.s3SecretVisible) VisualTransformation.None else PasswordVisualTransformation(),
                 trailingIcon = {
                     IconButton(onClick = { actions.onS3SecretVisibleChange(!state.s3SecretVisible) }) {
@@ -666,6 +702,8 @@ private fun SyncSettingsSection(
             onValueChange = actions.onSecretChange,
             label = { Text("Encryption Secret") },
             modifier = Modifier.fillMaxWidth(),
+            singleLine = true,
+            keyboardOptions = VerbatimKeyboard.copy(keyboardType = KeyboardType.Password),
             visualTransformation = if (state.secretVisible) VisualTransformation.None else PasswordVisualTransformation(),
             trailingIcon = {
                 IconButton(onClick = { actions.onSecretVisibleChange(!state.secretVisible) }) {
@@ -681,6 +719,15 @@ private fun SyncSettingsSection(
                     unfocusedContainerColor = MaterialTheme.colorScheme.surface,
                 ),
         )
+
+        state.validationError?.let { error ->
+            Text(
+                text = error,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.error,
+                modifier = Modifier.fillMaxWidth().testTag("SyncSettingsError"),
+            )
+        }
 
         Row(
             modifier = Modifier.fillMaxWidth(),

--- a/android/app/src/main/kotlin/com/brokenpip3/fatto/vm/SettingsViewModel.kt
+++ b/android/app/src/main/kotlin/com/brokenpip3/fatto/vm/SettingsViewModel.kt
@@ -2,6 +2,7 @@ package com.brokenpip3.fatto.vm
 
 import android.util.Log
 import androidx.lifecycle.ViewModel
+import com.brokenpip3.fatto.data.S3SettingsValidator
 import com.brokenpip3.fatto.data.SettingsRepository
 import com.brokenpip3.fatto.data.SyncType
 import com.brokenpip3.fatto.data.TaskrcImportPreview
@@ -40,6 +41,10 @@ class SettingsViewModel(private val repository: SettingsRepository) : ViewModel(
 
     private val _s3SecretAccessKey = MutableStateFlow("")
     val s3SecretAccessKey = _s3SecretAccessKey.asStateFlow()
+
+    /** Why the last [save] was refused, or null if it succeeded. */
+    private val _syncSettingsError = MutableStateFlow<String?>(null)
+    val syncSettingsError = _syncSettingsError.asStateFlow()
 
     private val _showCompleted = MutableStateFlow(true)
     val showCompleted = _showCompleted.asStateFlow()
@@ -331,6 +336,7 @@ class SettingsViewModel(private val repository: SettingsRepository) : ViewModel(
     fun save(): Boolean {
         val type = _syncType.value
         val secret = _encryptionSecret.value.trim()
+        _syncSettingsError.value = null
 
         val saved =
             when (type) {
@@ -345,17 +351,32 @@ class SettingsViewModel(private val repository: SettingsRepository) : ViewModel(
 
     private fun saveS3Credentials(secret: String): Boolean {
         val bucket = _s3Bucket.value.trim()
+        val region = _s3Region.value.trim()
+        val endpointUrl = _s3EndpointUrl.value.trim()
         val accessKeyId = _s3AccessKeyId.value.trim()
         val secretAccessKey = _s3SecretAccessKey.value.trim()
-        if (bucket.isEmpty() || accessKeyId.isEmpty() || secretAccessKey.isEmpty() || secret.isEmpty()) {
-            Log.d("SettingsViewModel", "Not saving: incomplete S3 credentials")
+
+        // Credentials that are merely malformed are rejected here: S3 reports
+        // them as a signature mismatch, which is impossible to act on.
+        val error =
+            S3SettingsValidator.validate(
+                bucket = bucket,
+                region = region,
+                endpointUrl = endpointUrl,
+                accessKeyId = accessKeyId,
+                secretAccessKey = secretAccessKey,
+                encryptionSecret = secret,
+            )
+        if (error != null) {
+            Log.d("SettingsViewModel", "Not saving S3 credentials: $error")
+            _syncSettingsError.value = error
             return false
         }
         Log.d("SettingsViewModel", "Saving S3 settings to repository")
         repository.saveS3Credentials(
             bucket = bucket,
-            region = _s3Region.value.trim().ifEmpty { null },
-            endpointUrl = _s3EndpointUrl.value.trim().ifEmpty { null },
+            region = region.ifEmpty { null },
+            endpointUrl = endpointUrl.ifEmpty { null },
             accessKeyId = accessKeyId,
             secretAccessKey = secretAccessKey,
             secret = secret,
@@ -368,6 +389,7 @@ class SettingsViewModel(private val repository: SettingsRepository) : ViewModel(
         val clientId = _clientId.value.trim()
         if (url.isEmpty() || clientId.isEmpty() || secret.isEmpty()) {
             Log.d("SettingsViewModel", "Not saving: incomplete server credentials")
+            _syncSettingsError.value = "Fill in the server URL, client ID and encryption secret"
             return false
         }
         Log.d("SettingsViewModel", "Saving server settings to repository")

--- a/android/app/src/test/kotlin/com/brokenpip3/fatto/S3SettingsValidatorTest.kt
+++ b/android/app/src/test/kotlin/com/brokenpip3/fatto/S3SettingsValidatorTest.kt
@@ -1,0 +1,99 @@
+package com.brokenpip3.fatto
+
+import com.brokenpip3.fatto.data.S3SettingsValidator
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class S3SettingsValidatorTest {
+    private fun validate(
+        bucket: String = "fatto-tasks",
+        region: String = "eu-west-2",
+        endpointUrl: String = "",
+        accessKeyId: String = ACCESS_KEY_ID,
+        secretAccessKey: String = SECRET_ACCESS_KEY,
+        encryptionSecret: String = "encryption-secret",
+    ) = S3SettingsValidator.validate(
+        bucket = bucket,
+        region = region,
+        endpointUrl = endpointUrl,
+        accessKeyId = accessKeyId,
+        secretAccessKey = secretAccessKey,
+        encryptionSecret = encryptionSecret,
+    )
+
+    @Test
+    fun `accepts a complete aws configuration`() {
+        assertNull(validate())
+        assertNull(validate(region = ""))
+    }
+
+    @Test
+    fun `names the missing field`() {
+        assertTrue(validate(bucket = "").orEmpty().contains("Bucket"))
+        assertTrue(validate(accessKeyId = "").orEmpty().contains("Access key ID"))
+        assertTrue(validate(secretAccessKey = "").orEmpty().contains("Secret access key"))
+        assertTrue(validate(encryptionSecret = "").orEmpty().contains("Encryption secret"))
+    }
+
+    @Test
+    fun `rejects credentials containing whitespace`() {
+        assertNotNull(validate(accessKeyId = "AKIAIOSF ODNN7EXAMPL"))
+        assertNotNull(validate(secretAccessKey = SECRET_ACCESS_KEY.replaceRange(5, 6, " ")))
+    }
+
+    @Test
+    fun `rejects quoted or escaped aws credentials`() {
+        assertNotNull(validate(accessKeyId = "\"$ACCESS_KEY_ID\""))
+        assertNotNull(validate(secretAccessKey = SECRET_ACCESS_KEY.replace("/", "\\/")))
+    }
+
+    @Test
+    fun `rejects temporary aws credentials`() {
+        assertTrue(validate(accessKeyId = "ASIAIOSFODNN7EXAMPLE").orEmpty().contains("session token"))
+    }
+
+    @Test
+    fun `rejects region names that are not aws regions`() {
+        for (region in listOf("eu-west", "EU-WEST-2", "eu_west_2", "eu-west-", "europe")) {
+            assertNotNull("$region should be rejected", validate(region = region))
+        }
+        for (region in listOf("us-east-1", "eu-west-2", "us-gov-east-1", "cn-northwest-1")) {
+            assertNull("$region should be accepted", validate(region = region))
+        }
+    }
+
+    @Test
+    fun `rejects invalid bucket names`() {
+        assertNotNull(validate(bucket = "My.Tasks"))
+        assertNotNull(validate(bucket = "ab"))
+        assertNotNull(validate(bucket = "-tasks"))
+        assertNotNull(validate(bucket = "tasks..backup"))
+        assertNull(validate(bucket = "tasks.backup-1"))
+    }
+
+    @Test
+    fun `checks key and region shape only for aws`() {
+        // S3-compatible services choose their own credentials and region names.
+        assertNull(
+            validate(
+                endpointUrl = "http://localhost:9000",
+                region = "garage",
+                accessKeyId = "minioadmin",
+                secretAccessKey = "minioadmin",
+            ),
+        )
+    }
+
+    @Test
+    fun `requires a scheme on the endpoint url`() {
+        assertNotNull(validate(endpointUrl = "minio.example.com"))
+        assertNull(validate(endpointUrl = "https://minio.example.com"))
+    }
+
+    private companion object {
+        const val ACCESS_KEY_ID = "AKIAIOSFODNN7EXAMPLE"
+        const val SECRET_ACCESS_KEY = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+    }
+}

--- a/android/app/src/test/kotlin/com/brokenpip3/fatto/SettingsViewModelTest.kt
+++ b/android/app/src/test/kotlin/com/brokenpip3/fatto/SettingsViewModelTest.kt
@@ -20,6 +20,12 @@ import org.junit.Test
 import java.util.Calendar
 
 class SettingsViewModelTest {
+    private companion object {
+        // The credentials AWS uses in its own documentation examples.
+        const val ACCESS_KEY_ID = "AKIAIOSFODNN7EXAMPLE"
+        const val SECRET_ACCESS_KEY = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+    }
+
     @Test
     fun `preview taskrc import does not mutate repository`() {
         val repository = FakeSettingsRepository()
@@ -80,23 +86,96 @@ class SettingsViewModelTest {
 
         viewModel.onSyncTypeChange(SyncType.S3)
         viewModel.onS3BucketChange("my-bucket")
-        viewModel.onS3AccessKeyIdChange("access-key")
-        viewModel.onS3SecretAccessKeyChange("secret-key")
+        viewModel.onS3AccessKeyIdChange(ACCESS_KEY_ID)
+        viewModel.onS3SecretAccessKeyChange(SECRET_ACCESS_KEY)
         viewModel.onSecretChange("encryption-secret")
 
         assertTrue(viewModel.save())
+        assertNull(viewModel.syncSettingsError.value)
         assertEquals(SyncType.S3, repository.getSyncType())
         assertEquals(
             S3Credentials(
                 bucket = "my-bucket",
                 region = null,
                 endpointUrl = null,
-                accessKeyId = "access-key",
-                secretAccessKey = "secret-key",
+                accessKeyId = ACCESS_KEY_ID,
+                secretAccessKey = SECRET_ACCESS_KEY,
                 secret = "encryption-secret",
             ),
             repository.getS3Credentials(),
         )
+    }
+
+    @Test
+    fun `save trims credentials picked up from a paste`() {
+        val repository = FakeSettingsRepository()
+        val viewModel = SettingsViewModel(repository)
+
+        viewModel.onSyncTypeChange(SyncType.S3)
+        viewModel.onS3BucketChange(" my-bucket ")
+        viewModel.onS3RegionChange(" eu-west-2\n")
+        viewModel.onS3AccessKeyIdChange("$ACCESS_KEY_ID\n")
+        viewModel.onS3SecretAccessKeyChange(" $SECRET_ACCESS_KEY ")
+        viewModel.onSecretChange("encryption-secret")
+
+        assertTrue(viewModel.save())
+        val saved = repository.getS3Credentials()
+        assertEquals("my-bucket", saved?.bucket)
+        assertEquals("eu-west-2", saved?.region)
+        assertEquals(ACCESS_KEY_ID, saved?.accessKeyId)
+        assertEquals(SECRET_ACCESS_KEY, saved?.secretAccessKey)
+    }
+
+    @Test
+    fun `save rejects malformed aws credentials with a specific reason`() {
+        val repository = FakeSettingsRepository()
+        val viewModel = SettingsViewModel(repository)
+
+        viewModel.onSyncTypeChange(SyncType.S3)
+        viewModel.onS3BucketChange("my-bucket")
+        viewModel.onS3AccessKeyIdChange("\"$ACCESS_KEY_ID\"")
+        viewModel.onS3SecretAccessKeyChange(SECRET_ACCESS_KEY)
+        viewModel.onSecretChange("encryption-secret")
+
+        assertFalse(viewModel.save())
+        assertNull(repository.getS3Credentials())
+        assertTrue(viewModel.syncSettingsError.value.orEmpty().contains("Access key ID"))
+    }
+
+    @Test
+    fun `save rejects a region that is not an aws region`() {
+        val repository = FakeSettingsRepository()
+        val viewModel = SettingsViewModel(repository)
+
+        viewModel.onSyncTypeChange(SyncType.S3)
+        viewModel.onS3BucketChange("my-bucket")
+        viewModel.onS3RegionChange("eu-west")
+        viewModel.onS3AccessKeyIdChange(ACCESS_KEY_ID)
+        viewModel.onS3SecretAccessKeyChange(SECRET_ACCESS_KEY)
+        viewModel.onSecretChange("encryption-secret")
+
+        assertFalse(viewModel.save())
+        assertTrue(viewModel.syncSettingsError.value.orEmpty().contains("eu-west"))
+
+        viewModel.onS3RegionChange("eu-west-2")
+        assertTrue(viewModel.save())
+        assertNull(viewModel.syncSettingsError.value)
+    }
+
+    @Test
+    fun `save accepts the credentials of an s3 compatible service`() {
+        val repository = FakeSettingsRepository()
+        val viewModel = SettingsViewModel(repository)
+
+        viewModel.onSyncTypeChange(SyncType.S3)
+        viewModel.onS3BucketChange("fatto-tasks")
+        viewModel.onS3EndpointUrlChange("http://localhost:9000")
+        viewModel.onS3AccessKeyIdChange("minioadmin")
+        viewModel.onS3SecretAccessKeyChange("minioadmin")
+        viewModel.onSecretChange("encryption-secret")
+
+        assertTrue(viewModel.save())
+        assertEquals("http://localhost:9000", repository.getS3Credentials()?.endpointUrl)
     }
 
     @Test
@@ -123,8 +202,8 @@ class SettingsViewModelTest {
             bucket = "my-bucket",
             region = null,
             endpointUrl = null,
-            accessKeyId = "access-key",
-            secretAccessKey = "secret-key",
+            accessKeyId = ACCESS_KEY_ID,
+            secretAccessKey = SECRET_ACCESS_KEY,
             secret = "s3-secret",
         )
         repository.setSyncType(SyncType.SERVER)

--- a/rust/taskchampion-android/src/lib.rs
+++ b/rust/taskchampion-android/src/lib.rs
@@ -380,30 +380,263 @@ impl ReplicaWrapper {
         secret_access_key: String,
         encryption_secret: String,
     ) -> Result<()> {
-        let mut replica = self.inner.lock().unwrap();
+        let settings = AwsSettings::validate(
+            bucket,
+            region,
+            endpoint_url,
+            access_key_id,
+            secret_access_key,
+            encryption_secret,
+        )?;
 
-        // Normalize empty optional strings coming across the FFI boundary to `None`.
-        let region = region.filter(|s| !s.is_empty());
-        let endpoint_url = endpoint_url.filter(|s| !s.is_empty());
+        let mut replica = self.inner.lock().unwrap();
 
         let config = ServerConfig::Aws {
             // S3-compatible endpoints generally require path-style addressing; real
             // AWS S3 (no custom endpoint) keeps the default virtual-hosted style.
-            force_path_style: endpoint_url.is_some(),
-            region,
-            bucket,
-            endpoint_url,
+            force_path_style: settings.endpoint_url.is_some(),
+            region: settings.region,
+            bucket: settings.bucket,
+            endpoint_url: settings.endpoint_url,
             credentials: AwsCredentials::AccessKey {
-                access_key_id,
-                secret_access_key,
+                access_key_id: settings.access_key_id,
+                secret_access_key: settings.secret_access_key,
             },
-            encryption_secret: encryption_secret.into_bytes(),
+            encryption_secret: settings.encryption_secret.into_bytes(),
         };
-        self.rt.block_on(async {
-            let mut server = config.into_server().await?;
-            replica.sync(&mut server, false).await
-        })?;
+        self.rt
+            .block_on(async {
+                let mut server = config.into_server().await?;
+                replica.sync(&mut server, false).await
+            })
+            .map_err(|e| TaskError::Internal(explain_aws_error(&e.to_string())))?;
         Ok(())
+    }
+}
+
+/// S3 settings that have been normalized and checked for the mistakes that would
+/// otherwise surface as an opaque S3 error at sync time.
+struct AwsSettings {
+    bucket: String,
+    region: Option<String>,
+    endpoint_url: Option<String>,
+    access_key_id: String,
+    secret_access_key: String,
+    encryption_secret: String,
+}
+
+impl AwsSettings {
+    /// Validate the settings for an S3 sync.
+    ///
+    /// The values arrive from a text form on a phone, where a stray space, a
+    /// newline from a paste or a mistyped region are easy to produce and
+    /// impossible to see. S3 answers all of those with the same opaque
+    /// `SignatureDoesNotMatch` (or a connection timeout), so the mistakes that
+    /// can be recognized without talking to the server are rejected here with a
+    /// message naming the field.
+    ///
+    /// Checks that only hold for real AWS (key shapes, region names) are applied
+    /// only when no custom endpoint is set: S3-compatible services such as minio
+    /// or Garage use credentials and regions of their own choosing.
+    fn validate(
+        bucket: String,
+        region: Option<String>,
+        endpoint_url: Option<String>,
+        access_key_id: String,
+        secret_access_key: String,
+        encryption_secret: String,
+    ) -> Result<Self> {
+        // Normalize: surrounding whitespace and empty optionals coming across the
+        // FFI boundary are never meaningful.
+        let bucket = bucket.trim().to_string();
+        let access_key_id = access_key_id.trim().to_string();
+        let secret_access_key = secret_access_key.trim().to_string();
+        let encryption_secret = encryption_secret.trim().to_string();
+        let region = region
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+        let endpoint_url = endpoint_url
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+
+        if bucket.is_empty() {
+            return Err(invalid("Bucket is required"));
+        }
+        if access_key_id.is_empty() {
+            return Err(invalid("Access key ID is required"));
+        }
+        if secret_access_key.is_empty() {
+            return Err(invalid("Secret access key is required"));
+        }
+        if encryption_secret.is_empty() {
+            return Err(invalid("Encryption secret is required"));
+        }
+
+        validate_bucket_name(&bucket)?;
+
+        // Interior whitespace in a key is always a mistake, and one that the
+        // server can only report as a signature mismatch.
+        if access_key_id.chars().any(char::is_whitespace) {
+            return Err(invalid(
+                "Access key ID must not contain spaces or line breaks",
+            ));
+        }
+        if secret_access_key.chars().any(char::is_whitespace) {
+            return Err(invalid(
+                "Secret access key must not contain spaces or line breaks",
+            ));
+        }
+
+        if let Some(url) = &endpoint_url {
+            if !url.starts_with("http://") && !url.starts_with("https://") {
+                return Err(invalid(
+                    "Endpoint URL must start with http:// or https:// (e.g. https://minio.example.com)",
+                ));
+            }
+        } else {
+            // No endpoint means real AWS, where the credential and region formats
+            // are fixed and worth checking.
+            validate_aws_access_key_id(&access_key_id)?;
+            validate_aws_secret_access_key(&secret_access_key)?;
+            if let Some(region) = &region {
+                validate_aws_region(region)?;
+            }
+        }
+
+        Ok(Self {
+            bucket,
+            region,
+            endpoint_url,
+            access_key_id,
+            secret_access_key,
+            encryption_secret,
+        })
+    }
+}
+
+fn invalid(message: &str) -> TaskError {
+    TaskError::Internal(message.into())
+}
+
+/// Check a bucket name against the S3 bucket naming rules, which minio and
+/// Garage share with AWS.
+fn validate_bucket_name(bucket: &str) -> Result<()> {
+    const RULES: &str =
+        "Bucket names must be 3-63 characters of lowercase letters, digits, dots and hyphens, \
+         and start and end with a letter or digit";
+    let valid_chars = bucket
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-' || c == '.');
+    let valid_edges = bucket
+        .chars()
+        .next()
+        .is_some_and(|c| c.is_ascii_lowercase() || c.is_ascii_digit())
+        && bucket
+            .chars()
+            .next_back()
+            .is_some_and(|c| c.is_ascii_lowercase() || c.is_ascii_digit());
+    if !(3..=63).contains(&bucket.len()) || !valid_chars || !valid_edges || bucket.contains("..") {
+        return Err(invalid(&format!("Invalid bucket name '{bucket}'. {RULES}")));
+    }
+    Ok(())
+}
+
+/// AWS access key IDs are 16-128 upper-case alphanumeric characters, in practice
+/// `AKIA` (long-lived) or `ASIA` (temporary) followed by 16 characters.
+fn validate_aws_access_key_id(access_key_id: &str) -> Result<()> {
+    if !(16..=128).contains(&access_key_id.len())
+        || !access_key_id
+            .chars()
+            .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit())
+    {
+        return Err(invalid(
+            "Access key ID does not look like an AWS key: it should be 16-128 upper-case letters \
+             and digits, such as AKIAIOSFODNN7EXAMPLE. Check for stray quotes, backslashes or \
+             characters added while typing",
+        ));
+    }
+    if access_key_id.starts_with("ASIA") {
+        return Err(invalid(
+            "This is a temporary AWS access key (ASIA...), which also requires a session token. \
+             Use a long-lived IAM user key (AKIA...) instead",
+        ));
+    }
+    Ok(())
+}
+
+/// AWS secret access keys are exactly 40 base64 characters.
+fn validate_aws_secret_access_key(secret_access_key: &str) -> Result<()> {
+    let valid_chars = secret_access_key
+        .chars()
+        .all(|c| c.is_ascii_alphanumeric() || c == '+' || c == '/' || c == '=');
+    if secret_access_key.len() != 40 || !valid_chars {
+        return Err(invalid(
+            "Secret access key does not look like an AWS secret: it should be exactly 40 \
+             characters of letters, digits, '+', '/' and '='. Backslashes and quotes are not part \
+             of the key and must not be escaped or included",
+        ));
+    }
+    Ok(())
+}
+
+/// AWS region names are `<area>-<direction>-<number>`, e.g. `eu-west-2` or
+/// `us-gov-east-1`. A region that is merely misspelled resolves to nothing and
+/// surfaces as a connection failure after a long wait.
+fn validate_aws_region(region: &str) -> Result<()> {
+    let parts: Vec<&str> = region.split('-').collect();
+    let Some((number, words)) = parts.split_last() else {
+        return Err(invalid_region(region));
+    };
+    let words_ok = words.len() >= 2
+        && words
+            .iter()
+            .all(|w| !w.is_empty() && w.chars().all(|c| c.is_ascii_lowercase()));
+    let number_ok = !number.is_empty() && number.chars().all(|c| c.is_ascii_digit());
+    if !words_ok || !number_ok {
+        return Err(invalid_region(region));
+    }
+    Ok(())
+}
+
+fn invalid_region(region: &str) -> TaskError {
+    invalid(&format!(
+        "'{region}' is not an AWS region name. Regions look like eu-west-2 or us-east-1. Leave the \
+         field empty to use us-east-1, or set an endpoint URL when using an S3-compatible service"
+    ))
+}
+
+/// Turn the S3 error codes users actually hit into an explanation of what to
+/// check, keeping the original message for reference.
+fn explain_aws_error(message: &str) -> String {
+    let hint = if message.contains("SignatureDoesNotMatch") {
+        Some(
+            "S3 rejected the request signature. The access key ID and secret access key must be \
+             copied exactly, with no missing, extra or auto-corrected characters",
+        )
+    } else if message.contains("InvalidAccessKeyId") {
+        Some("S3 does not know this access key ID. Check the key, and that it belongs to the same account as the bucket")
+    } else if message.contains("AccessDenied") {
+        Some(
+            "The credentials are valid but not allowed to use this bucket. The key needs \
+             s3:GetObject, s3:PutObject, s3:DeleteObject and s3:ListBucket on the bucket",
+        )
+    } else if message.contains("NoSuchBucket") {
+        Some("The bucket does not exist. Check the bucket name, and create it if needed")
+    } else if message.contains("PermanentRedirect")
+        || message.contains("AuthorizationHeaderMalformed")
+        || message.contains("IllegalLocationConstraint")
+    {
+        Some("The bucket lives in a different region than the one configured. Set the region the bucket was created in")
+    } else if message.contains("RequestTimeTooSkewed") {
+        Some("The device clock is too far from the real time for S3 to accept the request. Enable automatic date and time")
+    } else if message.contains("dispatch failure") || message.contains("error trying to connect") {
+        Some("Could not reach the S3 endpoint. Check the region, the endpoint URL and the network connection")
+    } else {
+        None
+    };
+    match hint {
+        Some(hint) => format!("{hint} (S3 said: {message})"),
+        None => message.to_string(),
     }
 }
 
@@ -1033,6 +1266,162 @@ mod tests {
             "encryption-secret".into(),
         );
         assert!(result.is_err());
+    }
+
+    /// Build a set of settings for a real AWS bucket, with `mutate` applied.
+    fn aws_settings(mutate: impl FnOnce(&mut AwsSettings)) -> Result<AwsSettings> {
+        let mut settings = AwsSettings {
+            bucket: "fatto-tasks".into(),
+            region: Some("eu-west-2".into()),
+            endpoint_url: None,
+            access_key_id: "AKIAIOSFODNN7EXAMPLE".into(),
+            secret_access_key: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY".into(),
+            encryption_secret: "encryption-secret".into(),
+        };
+        mutate(&mut settings);
+        AwsSettings::validate(
+            settings.bucket,
+            settings.region,
+            settings.endpoint_url,
+            settings.access_key_id,
+            settings.secret_access_key,
+            settings.encryption_secret,
+        )
+    }
+
+    #[test]
+    fn test_aws_settings_accepts_valid_aws_config() {
+        let settings = aws_settings(|_| {}).unwrap();
+        assert_eq!(settings.region.as_deref(), Some("eu-west-2"));
+        assert_eq!(settings.endpoint_url, None);
+    }
+
+    #[test]
+    fn test_aws_settings_trims_and_normalizes() {
+        let settings = aws_settings(|s| {
+            s.bucket = "  fatto-tasks\n".into();
+            s.region = Some("  ".into());
+            s.endpoint_url = Some(String::new());
+            s.access_key_id = " AKIAIOSFODNN7EXAMPLE\n".into();
+            s.secret_access_key = "\twJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY ".into();
+        })
+        .unwrap();
+        assert_eq!(settings.bucket, "fatto-tasks");
+        assert_eq!(settings.access_key_id, "AKIAIOSFODNN7EXAMPLE");
+        assert_eq!(
+            settings.secret_access_key,
+            "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+        );
+        assert_eq!(settings.region, None);
+        assert_eq!(settings.endpoint_url, None);
+    }
+
+    #[test]
+    fn test_aws_settings_rejects_missing_fields() {
+        assert!(aws_settings(|s| s.bucket = " ".into()).is_err(), "bucket");
+        assert!(
+            aws_settings(|s| s.access_key_id = String::new()).is_err(),
+            "access key id"
+        );
+        assert!(
+            aws_settings(|s| s.secret_access_key = String::new()).is_err(),
+            "secret access key"
+        );
+        assert!(
+            aws_settings(|s| s.encryption_secret = " ".into()).is_err(),
+            "encryption secret"
+        );
+    }
+
+    #[test]
+    fn test_aws_settings_rejects_whitespace_inside_credentials() {
+        assert!(aws_settings(|s| s.access_key_id = "AKIAIOSF ODNN7EXAMPL".into()).is_err());
+        assert!(aws_settings(
+            |s| s.secret_access_key = "wJalrXUtnFEMI/K7MDENG/bPxRfiCY EXAMPLEKE".into()
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn test_aws_settings_rejects_malformed_aws_credentials() {
+        // Escaped or quoted keys, the shapes users produce when they assume the
+        // field needs shell-style quoting.
+        assert!(aws_settings(|s| s.access_key_id = "\"AKIAIOSFODNN7EXAMPLE\"".into()).is_err());
+        assert!(aws_settings(
+            |s| s.secret_access_key = "wJalrXUtnFEMI\\/K7MDENG\\/bPxRfiCYEXAMPLEKEY".into()
+        )
+        .is_err());
+        // Temporary credentials need a session token, which is not supported.
+        assert!(aws_settings(|s| s.access_key_id = "ASIAIOSFODNN7EXAMPLE".into()).is_err());
+    }
+
+    #[test]
+    fn test_aws_settings_checks_key_shape_only_for_aws() {
+        // minio's default credentials are neither 20 nor 40 characters.
+        let settings = aws_settings(|s| {
+            s.endpoint_url = Some("http://localhost:9000".into());
+            s.region = None;
+            s.access_key_id = "minioadmin".into();
+            s.secret_access_key = "minioadmin".into();
+        })
+        .unwrap();
+        assert_eq!(
+            settings.endpoint_url.as_deref(),
+            Some("http://localhost:9000")
+        );
+    }
+
+    #[test]
+    fn test_aws_settings_requires_endpoint_scheme() {
+        assert!(aws_settings(|s| s.endpoint_url = Some("minio.example.com".into())).is_err());
+        assert!(
+            aws_settings(|s| s.endpoint_url = Some("https://minio.example.com".into())).is_ok()
+        );
+    }
+
+    #[test]
+    fn test_aws_settings_validates_region_names() {
+        for region in ["us-east-1", "eu-west-2", "us-gov-east-1", "cn-northwest-1"] {
+            assert!(
+                aws_settings(|s| s.region = Some(region.into())).is_ok(),
+                "{region} should be accepted"
+            );
+        }
+        // The mistake from the bug report: a region without its number.
+        for region in ["eu-west", "EU-WEST-2", "eu_west_2", "eu-west-", "europe"] {
+            assert!(
+                aws_settings(|s| s.region = Some(region.into())).is_err(),
+                "{region} should be rejected"
+            );
+        }
+        // S3-compatible services pick their own region names.
+        assert!(aws_settings(|s| {
+            s.endpoint_url = Some("http://localhost:9000".into());
+            s.region = Some("garage".into());
+        })
+        .is_ok());
+    }
+
+    #[test]
+    fn test_aws_settings_validates_bucket_names() {
+        assert!(aws_settings(|s| s.bucket = "My.Tasks".into()).is_err());
+        assert!(aws_settings(|s| s.bucket = "ab".into()).is_err());
+        assert!(aws_settings(|s| s.bucket = "-tasks".into()).is_err());
+        assert!(aws_settings(|s| s.bucket = "tasks..backup".into()).is_err());
+        assert!(aws_settings(|s| s.bucket = "tasks.backup-1".into()).is_ok());
+    }
+
+    #[test]
+    fn test_explain_aws_error_adds_hints() {
+        let explained = explain_aws_error("unhandled error (SignatureDoesNotMatch)");
+        assert!(explained.contains("access key ID and secret access key"));
+        assert!(explained.contains("SignatureDoesNotMatch"));
+
+        // Unknown errors are passed through untouched.
+        assert_eq!(
+            explain_aws_error("some other failure"),
+            "some other failure"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Refs #51

## Problem

S3 answers a mistyped key, a newline picked up while pasting and a misspelled region with the same opaque `SignatureDoesNotMatch`, so there was no way for a user to tell a wrong credential from a wrong region — which is exactly where #51 stalled.

## Changes

- **Validate the settings that can be checked without a network round trip**, in `SettingsViewModel` and again in `sync_aws`, so credentials that never went through the settings screen are covered too. Checks that only hold for real AWS (key shapes, region names) are skipped when a custom endpoint is set, since minio, Garage, R2 and the rest pick their own.
- **Explain the S3 error codes users actually hit** (`SignatureDoesNotMatch`, `NoSuchBucket`, `AccessDenied`, `PermanentRedirect`/`AuthorizationHeaderMalformed`, `RequestTimeTooSkewed`), keeping the original message for reference.
- **Stop the keyboard from rewriting credentials** — auto-correction, word suggestions and automatic capitalization all alter what was typed, and the result surfaces only as an authentication failure. Credential fields are now `singleLine` with capitalization and autocorrect off.
- Document the S3 fields per provider in the README.

## Verification

The existing integration test only covered path-style with an endpoint URL. Real AWS takes a different path — no endpoint means `force_path_style: false`, virtual-hosted addressing, and the region participating in the SigV4 signature — which was untested.

I exercised that path by pointing `AWS_ENDPOINT_URL_S3` (honored by taskchampion via `aws_config::defaults()`) at a minio configured with `MINIO_DOMAIN` + wildcard DNS and `region=eu-west-2`, using AWS-shaped credentials. The client code path is then identical to real AWS, against a server that enforces the region.

| Scenario | Result |
| --- | --- |
| AWS mode (virtual-hosted + region-signed), push→pull roundtrip | works |
| Path-style S3-compatible (endpoint set), roundtrip | works |
| Path-style with a non-AWS region name (`garage`) | works |
| Pasted values padded with spaces/tabs/newlines | trimmed, syncs |
| Wrong region in AWS mode | `AuthorizationHeaderMalformed` → "The bucket lives in a different region than the one configured…" |
| Wrong secret in AWS mode | `SignatureDoesNotMatch` → "S3 rejected the request signature. The access key ID and secret access key must be copied exactly…" |

**No false rejections** across 12 real provider config shapes — AWS (eu-west-2, no region, GovCloud, China, dotted bucket), minio, Cloudflare R2 (region `auto`, 32/64-hex creds), Backblaze B2, Wasabi, DigitalOcean Spaces, Garage, and a generic short-credential service. 7 malformed configs are each rejected with a message naming the field. The Rust and Kotlin validators produce identical verdicts and messages across the whole matrix.

`cargo test --lib` (29 passed), `cargo clippy --all-targets -D warnings` and `cargo fmt --check` are clean; the S3 integration test passes against the compose minio.

## Known gaps, not addressed here

- Connection failures still surface as a bare `unhandled error`: `taskchampion::Error::Other` is `#[error(transparent)]` over anyhow, and only aws-sdk's `Unhandled` variant appends a code, so the `dispatch failure` / `error trying to connect` branches never match. Wants a catch-all or walking `source()`.
- An endpoint URL pointing at AWS itself (`https://s3.eu-west-2.amazonaws.com`) bypasses the AWS key/region checks and switches to path-style addressing.
- Bucket-name rules are applied even with a custom endpoint, so an underscore bucket (allowed by Ceph RGW) or a legacy uppercase `us-east-1` bucket would be refused.
- The taskrc `sync.aws.*` keys from #51 are untouched — that is #52.

## Caveat

This was not tested against real AWS S3 (no account available). What is verified is the identical client code path against a region-enforcing S3 server, which covers the addressing and signing behaviour but not AWS-specific server quirks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
